### PR TITLE
Add scripts for installing golang and moving projects into the go workspace

### DIFF
--- a/circleci/golang-install
+++ b/circleci/golang-install
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Installs a specific release of golang
+#
+# Usage:
+#
+#   golang-install [GODIST]
+
+set -e
+
+# User supplied args
+GODIST=$1
+if [[ -z $GODIST ]]; then echo "Missing arg1 GODIST" && exit 1; fi
+
+
+INSTALL_ROOT=/usr/local
+
+# Download the golang package if needed
+mkdir -p download
+if [ ! -e download/$GODIST ]; then
+    echo -n "Downloading $GODIST ..."
+    curl -s -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    echo "Done"
+fi
+
+# Cleanup any existing versions and install the new one
+sudo rm -rf $INSTALL_ROOT/go
+echo -n "Extracting $GODIST"
+sudo tar -C $INSTALL_ROOT -xzf download/$GODIST
+echo "Done."
+echo "Golang installed successfully"

--- a/circleci/golang-move-project
+++ b/circleci/golang-move-project
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Moves a golang project from the default location to the golang workspace
+#
+# Usage:
+#
+#   golang-move-project
+#
+# Note: This script relies on CircleCI specific environment variables:
+#   - HOME
+#   - CIRCLE_PROJECT_REPONAME
+#   - CIRCLE_PROJECT_USERNAME
+
+
+set -e
+
+
+move_project() { 
+    # User supplied args
+    SRC=$1
+    if [[ -z $SRC ]]; then echo "Missing arg1 SRC" && exit 1; fi
+
+    DEST=$2
+    if [[ -z $DEST ]]; then echo "Missing arg2 DEST" && exit 1; fi
+
+
+    # Delete anything already in the destination
+    if [ -e $DEST ]; then
+        echo -n "Cleaning up previous contents in the destination..."
+        rm -rf $DEST
+        echo "Done"
+    fi
+
+    # Create the parent destination dir if it does not exist
+    PARENT_DIR=`dirname $DEST`
+    if [ ! -d $PARENT_DIR ]; then
+        echo -n "Creating parent dir..."
+        mkdir -p $PARENT_DIR
+        echo "Done"
+    fi
+
+    # move the src into the destination
+    echo -n "Moving files..."
+    mv $SRC $DEST
+    echo "Done"
+
+    # re-create the src dir for circleci
+    mkdir $SRC
+}
+
+move_project $HOME/$CIRCLE_PROJECT_REPONAME $HOME/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2093

These scripts implement the following common CircleCI patterns:

**golang-install** 
```
    - mkdir -p download
    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
    - sudo rm -rf /usr/local/go
    - sudo tar -C /usr/local -xzf download/$GODIST
```

now can be run as `./ci-scripts/golang-install $GODIST`

**golang-move-project**
```
    - mkdir -p $HOME/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME
    - rm -rf $HOME/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME || true
    - mv $HOME/$CIRCLE_PROJECT_REPONAME $HOME/.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
    - mkdir $HOME/$CIRCLE_PROJECT_REPONAME
```

 now can be run as `./ci-scripts/golang-move-project`


An example of a circleci.yaml we would like to simplify can be seen here:
https://github.com/Clever/wag-test/blob/circleci/circle.yml
