### PR TITLE
Fix catapult exit code and prevent prompting for password if wrong auth was given

### DIFF
--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -4,17 +4,26 @@
 #
 # Usage:
 #
-#   catapult-publish [CATAPULT_URL] [CATAPULT_AUTH] [APP_NAME]
+#   catapult-publish [CATAPULT_URL] [CATAPULT_USER] [CATAPULT_PASS] [APP_NAME]
+#
+# Required circleci provided environment variables:
+#
+#  CIRCLE_PROJECT_REPONAME
+#  CIRCLE_PROJECT_USERNAME
+#  CIRCLE_BUILD_NUM
+#
 
 set -e
 
 # User supplied args
 CATAPULT_URL=$1
 if [[ -z $CATAPULT_URL ]]; then echo "Missing arg1 CATAPULT_URL" && exit 1; fi
-CATAPULT_AUTH=$2
-if [[ -z $CATAPULT_AUTH ]]; then echo "Missing arg2 CATAPULT_AUTH" && exit 1; fi
-APP_NAME=$3
-if [[ -z $APP_NAME ]]; then echo "Missing arg3 APP_NAME" && exit 1; fi
+CATAPULT_USER=$2
+if [[ -z $CATAPULT_USER ]]; then echo "Missing arg2 CATAPULT_USER" && exit 1; fi
+CATAPULT_PASS=$3
+if [[ -z $CATAPULT_PASS ]]; then echo "Missing arg3 CATAPULT_PASS" && exit 1; fi
+APP_NAME=$4
+if [[ -z $APP_NAME ]]; then echo "Missing arg4 APP_NAME" && exit 1; fi
 
 # Set automatically by CircleCI
 : ${CIRCLE_PROJECT_REPONAME?"Missing required env var"}
@@ -25,8 +34,24 @@ USER=$CIRCLE_PROJECT_USERNAME
 BUILD_NUM=$CIRCLE_BUILD_NUM
 
 echo "Publishing to catapult..."
-curl -u $CATAPULT_AUTH \
+SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \
+  -w "%{http_code}" \
+  --output catapult.out \
   -H "Content-Type: application/json" \
   -X POST \
   -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\"}" \
-  $CATAPULT_URL
+  $CATAPULT_URL)
+
+if [ "$SC" -eq 200 ]; then
+  echo "Successfully published catapult application"
+  rm -f catapult.out
+  exit 0
+else
+  echo "Failed to publish catapult application"
+  echo "------------------------------------------------"
+  cat catapult.out
+  echo ""
+  echo "------------------------------------------------"
+  rm -f catapult.out
+  exit 1
+fi


### PR DESCRIPTION
Fix catapult-publish script to return proper exit codes. Also splits the username/password into two args so that if the wrong reds are set, it doesn't hang waiting for the user to input the password.

