### PR TITLE
Test gh release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ Runs [report-card](github.com/clever/report-card).
 ```
 $ ./circleci/report-card [DOCKER_USER] [DOCKER_PASS] [DOCKER_EMAIL] [GITHUB_TOKEN]
 ```
+
+### Mongo install (version 2.4 only)
+
+Installs Mongo version 2.4, rather than the default version in CircleCI.
+At time of writing, `v3.0.7` was default version in [Ubuntu 14.04 (Trusty) image](https://circleci.com/docs/build-image-trusty/#mongodb).
+
+```
+$ ./circleci/mongo-install-2.4
+```

--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,5 @@ test:
   # do a github release to this repo, using the commit SHA
   - mkdir artifacts
   - echo "foo" > artifacts/foo.txt
-  - echo "v${CIRCLE_SHA1:0:7}" > VERSION
+  - echo "${CIRCLE_SHA1:0:7}" > VERSION
   - ./circleci/github-release $GH_RELEASE_TOKEN artifacts/

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ test:
   - mkdir artifacts
   - touch artifacts/release-${CIRCLE_PROJECT_USERNAME}-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_SHA1}
   - echo "v${CIRCLE_SHA1}" > VERSION
-  - ./ci-scripts/circleci/github-release $GH_RELEASE_TOKEN artifacts/
+  - ./circleci/github-release $GH_RELEASE_TOKEN artifacts/

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,5 @@ test:
   - mkdir artifacts
   - echo "foo" > artifacts/foo.txt
   - echo "${CIRCLE_SHA1:0:7}" > VERSION
+  - ./circleci/mongo-install-2.4
   - ./circleci/github-release $GH_RELEASE_TOKEN artifacts/

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,6 @@ test:
   override:
   # do a github release to this repo, using the commit SHA
   - mkdir artifacts
-  - touch artifacts/release-${CIRCLE_PROJECT_USERNAME}-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_SHA1}
-  - echo "v${CIRCLE_SHA1}" > VERSION
+  - echo "foo" > artifacts/foo.txt
+  - echo "v${CIRCLE_SHA1:0:7}" > VERSION
   - ./circleci/github-release $GH_RELEASE_TOKEN artifacts/

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+test:
+  override:
+  # do a github release to this repo, using the commit SHA
+  - mkdir artifacts
+  - touch artifacts/release-${CIRCLE_PROJECT_USERNAME}-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_SHA1}
+  - echo "v${CIRCLE_SHA1}" > VERSION
+  - ./ci-scripts/circleci/github-release $GH_RELEASE_TOKEN artifacts/

--- a/circleci/github-release
+++ b/circleci/github-release
@@ -28,6 +28,7 @@ echo "Downloading github-release tool"
 curl -sSL -o /tmp/github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.5.2/linux-amd64-github-release.tar.bz2
 tar jxf /tmp/github-release.tar.bz2 -C /tmp/ && sudo mv /tmp/bin/linux/amd64/github-release /usr/local/bin/github-release
 
+echo "Publishing github-release"
 TAG=$(head -n 1 VERSION)
 DESCRIPTION=$(tail -n +2 VERSION)
 

--- a/circleci/mongo-install-2.4
+++ b/circleci/mongo-install-2.4
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Installs Mongo 2.4, rather than the default version in CircleCI.
+#
+# Usage:
+#
+#   mongo-install-2.4
+
+set -e
+
+echo "Stopping and removing currently installed Mongodb..."
+# the service running Mongo 3.x is `mongod` vs `mongodb` in 2.4
+sudo service mongod stop
+sudo apt-get purge mongodb-org*
+
+echo "Attempting to download Mongo version 2.4.14 ..."
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+sudo apt-get update
+sudo apt-get install -y mongodb-10gen=2.4.14
+
+echo "Restarting new version of Mongodb..."
+sudo service mongodb restart
+mongo --version
+
+echo "Mongo 2.4.14 installed successfully"


### PR DESCRIPTION
This is the first step toward having the `ci-scripts` repo test itself.

Every commit will now publish a github-release, with a title based on the short commit sha.