### PR TITLE
Adds cache-control header to assets uploaded to s3

### DIFF
--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -31,4 +31,4 @@ pip install awscli
 echo "Uploading files to s3..."
 echo "\tSource: $SOURCE_DIR"
 echo "\tDesination: $S3_BUCKET_URL"
-aws s3 cp $SOURCE_DIR $S3_BUCKET_URL --recursive --acl "private" --region "us-east-1"
+aws s3 cp $SOURCE_DIR $S3_BUCKET_URL --recursive --acl "private" --region "us-east-1" --cache-control "max-age=31536000"


### PR DESCRIPTION
Our primary CloudFront costs come from the bandwidth and requests of serving assets to users.

You can see the costs in the billing dashboard: https://console.aws.amazon.com/billing/home?region=us-west-1#/bill?year=2017&month=3

You can look at the reports for the different caches to see how many requests `assets.clever.com` is doing compared to the rest: https://console.aws.amazon.com/cloudfront/home?region=us-west-1#cache_stat_reports:

The CloudFront for assets.clever.com serves a lot of requests for fonts, scripts, etc: https://console.aws.amazon.com/cloudfront/home?region=us-west-1#popular_urls:

I think we should be able to cache our assets in users' browsers. This is inspired by this article: http://snowplowanalytics.com/blog/2013/07/02/reduce-your-cloudfront-bills-with-cache-control/

Since our assets never should change (we should just publish a new version), I figured we should cache as long as we can. Apparently, one year is the standard max `max-age` value: http://stackoverflow.com/a/25201898/2967120

If we do somehow add a `cache-control` header with a bad value to our sites, it could be difficult to change. However, I think that since we should always use `s3-upload` into a commit-namespaced folder, we should be fine.

-Not sure this will work with clever-components - verifying- should work now, see https://github.com/Clever/components/pull/133
