### PR TITLE
Bump to golang 1.7.6 and 1.8.3

### DIFF
--- a/circleci/golang-install
+++ b/circleci/golang-install
@@ -22,8 +22,8 @@ echo "Attempting to download Go version '$GO_VERSION'..."
 if [ "$GO_VERSION" == "1.4" ]; then GO_VERSION="1.4.3"; fi
 if [ "$GO_VERSION" == "1.5" ]; then GO_VERSION="1.5.4"; fi
 if [ "$GO_VERSION" == "1.6" ]; then GO_VERSION="1.6.4"; fi
-if [ "$GO_VERSION" == "1.7" ]; then GO_VERSION="1.7.5"; fi
-if [ "$GO_VERSION" == "1.8" ]; then GO_VERSION="1.8.1"; fi
+if [ "$GO_VERSION" == "1.7" ]; then GO_VERSION="1.7.6"; fi
+if [ "$GO_VERSION" == "1.8" ]; then GO_VERSION="1.8.3"; fi
 
 GODIST=go$GO_VERSION.linux-amd64.tar.gz
 


### PR DESCRIPTION
Release Notes: https://golang.org/doc/devel/release.html

* go1.7.6 (released 2017/05/23) includes the same security fix as Go 1.8.2 and was released at the same time. See the Go 1.8.2 milestone on our issue tracker for details.

* go1.8.2 (released 2017/05/23) includes a security fix to the crypto/elliptic package. See the Go 1.8.2 milestone on our issue tracker for details.
* go1.8.3 (released 2017/05/24) includes fixes to the compiler, runtime, documentation, and the database/sql package.
