### PR TITLE
don't exit before publishing

### DIFF
--- a/circleci/workflow-publish
+++ b/circleci/workflow-publish
@@ -50,8 +50,6 @@ CURL_DATA="{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NU
 echo "Publishing to workflow-manager..."
 echo $CURL_DATA | python -m json.tool
 
-exit 1
-
 CURL_OUTPUT="workflow-manager.out"
 SC=$(curl -u $WF_USER:$WF_PASS \
   -w "%{http_code}" \


### PR DESCRIPTION
The script seems to be exiting with a non-zero code before publishing the workflow