### PR TITLE
disable report-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ $ ./circleci/workflow-publish [WF_URL] [WF_USER] [WF_PASS] [WF_JSON]
 
 #### Report-card
 
-Runs [report-card](https://github.com/clever/report-card).
+Disabled.
 
-```
-$ ./circleci/report-card [DOCKER_USER] [DOCKER_PASS] [DOCKER_EMAIL] [GITHUB_TOKEN]
-```
-
+We still are keeping the script here so that repos that invoke it can do so safely.
+But it is a no-op.

--- a/circleci/report-card
+++ b/circleci/report-card
@@ -1,45 +1,10 @@
 #!/bin/bash
 
-# Runs report-card to analyze a repo's code health.
-#
-# Usage:
-#
-#   report-card [DOCKER_USER] [DOCKER_PASS] [DOCKER_EMAIL] [GITHUB_TOKEN]
-#
+# DISABLED
 
-if [ $# -ne 4 ]; then
-    echo "Incorrect number of arguments given. Expected 4, received $#"
-    echo "Usage: report-card [DOCKER_USER] [DOCKER_PASS] [DOCKER_EMAIL] [GITHUB_TOKEN]"
-    exit 1
-fi
-
-# User supplied args
-DOCKER_USER=$1
-DOCKER_PASS=$2
-DOCKER_EMAIL=$3
-GITHUB_TOKEN=$4
-
-
-REPORT_CARD_IMAGE="0babaab"
-
-echo "Logging into DockerHub..."
-docker login -u $DOCKER_USER -p $DOCKER_PASS --email="$DOCKER_EMAIL" || docker login -u $DOCKER_USER -p $DOCKER_PASS
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to login to dockerhub"
-    exit 1
-fi
-
-echo "Pulling report-card:$REPORT_CARD_IMAGE ..."
-timeout 5m docker pull clever/report-card:$REPORT_CARD_IMAGE
-if [ $? -ne 0 ]; then
-    echo "ERROR: Timed out while pulling report-card image. A rebuild should fix this."
-    exit 1
-fi
-
-echo "Running report-card..."
-docker run -t \
-    -v `pwd`:/repo/$(basename `pwd`) \
-    -e GITHUB_API_TOKEN=$GITHUB_TOKEN \
-    clever/report-card:$REPORT_CARD_IMAGE \
-    --repo /repo/$(basename `pwd`) --publish
-exit $?
+echo "Report card has been disabled until further notice."
+echo ""
+echo "Why?"
+echo "-> It was  not providing useful info for users"
+echo "-> It was making builds slower and in some cases failing them due to Docker pull issues"
+exit 0


### PR DESCRIPTION
Unless/until we have time to revisit it, report-card is a net negative for repos.

Let's disable it. This should lead to faster/more stable builds.