### PR TITLE
bump Go 1.9 and add Go 1.10

### DIFF
--- a/circleci/golang-install
+++ b/circleci/golang-install
@@ -28,7 +28,8 @@ if [ "$GO_VERSION" == "1.7" ]; then GO_VERSION="1.7.6"; fi
 
 # Active Golang versions
 if [ "$GO_VERSION" == "1.8" ]; then GO_VERSION="1.8.7"; fi
-if [ "$GO_VERSION" == "1.9" ]; then GO_VERSION="1.9.4"; fi
+if [ "$GO_VERSION" == "1.9" ]; then GO_VERSION="1.9.5"; fi
+if [ "$GO_VERSION" == "1.10" ]; then GO_VERSION="1.10.1"; fi
 
 GODIST=go$GO_VERSION.linux-amd64.tar.gz
 


### PR DESCRIPTION
https://golang.org/doc/devel/release.html#go1.10.minor

> go1.9.5 (released 2018/03/28) includes fixes to the compiler, go command, and net/http/pprof package. See the Go 1.9.5 milestone on our issue tracker for details.