### PR TITLE
[INFRA-3134] install awscli as part of ecr publish

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -20,6 +20,7 @@ check_hub_vars() {
 }
 
 push_hub_image() {
+  echo "Pushing image to DockerHub..."
   docker push $ORG/$REPO:$SHORT_SHA
 }
 
@@ -32,6 +33,7 @@ check_ecr_vars() {
 
 install_awscli(){
   # awscli required for ECR publish steps
+  echo "Downloading and installing awscli..."
   wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
   sudo pip install --upgrade awscli && aws --version
   pip install --upgrade --user awscli
@@ -43,9 +45,9 @@ ecr_login(){
 }
 
 push_ecr_image(){
-  echo "tag"
+  echo "Tagging image for ECR..."
 	docker tag $ORG/$REPO:$SHORT_SHA $ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/$REPO:$SHORT_SHA
-  echo "push"
+  echo "Pushing image to ECR..."
 	docker push $ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/$REPO:$SHORT_SHA
 }
 
@@ -71,9 +73,10 @@ fi
 
 # dockerhub login.
 # `FROM image` in Dockerfile is going to pull from DockerHub
-docker login -u $DOCKER_USER -p $DOCKER_PASS  || docker login -u $DOCKER_USER -p $DOCKER_PASS
+docker login -u $DOCKER_USER -p $DOCKER_PASS --email="$DOCKER_EMAIL"  || docker login -u $DOCKER_USER -p $DOCKER_PASS
 if [ "$ECR_PUSH_ID" != "" ]; then
   echo "ECR access_id available. Logging into ECR..."
+  install_awscli
   ecr_login
 fi
 
@@ -86,6 +89,5 @@ push_hub_image
 # all repos eventually should dual publish (or explicitly opt-out)
 if [ "$ECR_PUSH_ID" != "" ]; then
   echo "ECR access_id available. Pushing to ECR..."
-  install_awscli
   push_ecr_image
 fi

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -30,12 +30,22 @@ check_ecr_vars() {
   if [[ -z $ECR_PUSH_SECRET ]]; then echo "Missing var for ECR: ECR_PUSH_SECRET" && exit 1; fi
 }
 
+install_awscli(){
+  # awscli required for ECR publish steps
+  wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
+  sudo pip install --upgrade awscli && aws --version
+  pip install --upgrade --user awscli
+
+}
+
 ecr_login(){
 	eval $(AWS_ACCESS_KEY_ID=$ECR_PUSH_ID AWS_SECRET_ACCESS_KEY=$ECR_PUSH_SECRET aws ecr --region $ECR_REGION get-login --include-email) || eval $(AWS_ACCESS_KEY_ID=$ECR_PUSH_ID AWS_SECRET_ACCESS_KEY=$ECR_PUSH_SECRET aws ecr --region $ECR_REGION get-login --no-include-email)
 }
 
 push_ecr_image(){
+  echo "tag"
 	docker tag $ORG/$REPO:$SHORT_SHA $ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/$REPO:$SHORT_SHA
+  echo "push"
 	docker push $ECR_ACCOUNT_ID.dkr.ecr.$ECR_REGION.amazonaws.com/$REPO:$SHORT_SHA
 }
 
@@ -61,7 +71,7 @@ fi
 
 # dockerhub login.
 # `FROM image` in Dockerfile is going to pull from DockerHub
-docker login -u $DOCKER_USER -p $DOCKER_PASS --email="$DOCKER_EMAIL" || docker login -u $DOCKER_USER -p $DOCKER_PASS
+docker login -u $DOCKER_USER -p $DOCKER_PASS  || docker login -u $DOCKER_USER -p $DOCKER_PASS
 if [ "$ECR_PUSH_ID" != "" ]; then
   echo "ECR access_id available. Logging into ECR..."
   ecr_login
@@ -76,5 +86,6 @@ push_hub_image
 # all repos eventually should dual publish (or explicitly opt-out)
 if [ "$ECR_PUSH_ID" != "" ]; then
   echo "ECR access_id available. Pushing to ECR..."
+  install_awscli
   push_ecr_image
 fi


### PR DESCRIPTION
ECR push requires awscli

Validated that this change is effective for CircleCI 2.0 by trying it with hubble: 
- code in https://github.com/Clever/hubble/commit/05e6c02361a249d374b7ba6a27bb8d510ccce439 (will remove branch from hubble after this check)
- build at https://circleci.com/gh/Clever/hubble/455

Actually, this broke, so holding off on this optimization. We can do it after September. 