### PR TITLE
if lambda function has a swagger.yml, upload it as an artifact

### DIFF
--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -49,6 +49,16 @@ AWS_REGION=$AWS_REGION \
           AWS_SECRET_ACCESS_KEY=$LAMBDA_AWS_SECRET_ACCESS_KEY \
           aws s3 cp bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
 
+if [ -e swagger.yml ]; then
+    echo "Uploading swagger.yml"
+    # api gateway fails to parse on x-nullable
+    sed '/x-nullable/d' ./swagger.yml > ./swagger.lambda.yml
+    AWS_REGION=$AWS_REGION \
+              AWS_ACCESS_KEY_ID=$LAMBDA_AWS_ACCESS_KEY_ID \
+              AWS_SECRET_ACCESS_KEY=$LAMBDA_AWS_SECRET_ACCESS_KEY \
+              aws s3 cp swagger.lambda.yml s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${APP_NAME}/${SHORT_SHA}/swagger.lambda.yml
+fi
+
 # publish the application to catapult
 echo "Publishing to catapult..."
 SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \


### PR DESCRIPTION
Right now when a lambda function is built in circle, we upload the compiled binary to S3 using the `catapult-publish-lambda` script. This binary is later used by catapult when asking AWS to create the lambda function.

This PR changes the script to additionally upload the swagger.yml file, if it exists. This enables catapult to ask AWS to create an API in API Gateway that uses this swagger.yml, e.g. https://github.com/Clever/catapult/pull/529/files#diff-fac03256abbea4ed71cad194aabc1c41R193
