### PR TITLE
Remove local python code dir to ensure awscli install works correctly

### DIFF
--- a/circleci/utils
+++ b/circleci/utils
@@ -15,6 +15,7 @@ install_awscli(){
   fi
 
   echo "Installing AWS cli..."
+  rm -rf ~/.local
   wget --directory-prefix=/tmp/ https://bootstrap.pypa.io/get-pip.py
   sudo python /tmp/get-pip.py
 


### PR DESCRIPTION
Selenium workers were all failing their build.  Confirmed change works here: https://circleci.com/gh/Clever/infinitecampus/193 (note `fix-python-builds` branch was used when checking out ci-scripts)

Related: https://clever.atlassian.net/browse/INFRA-3343