### PR TITLE
Support github releases on OSX

### DIFF
--- a/circleci/github-release
+++ b/circleci/github-release
@@ -23,8 +23,13 @@ if [ ! -e VERSION ]; then echo "Missing VERSION file" && exit 1; fi
 
 # Download github-release script
 echo "Downloading github-release tool"
-curl -sSL -o /tmp/github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.5.2/linux-amd64-github-release.tar.bz2
-tar jxf /tmp/github-release.tar.bz2 -C /tmp/ && sudo mv /tmp/bin/linux/amd64/github-release /usr/local/bin/github-release
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  curl -sSL -o /tmp/github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.5.2/darwin-amd64-github-release.tar.bz2
+  tar jxf /tmp/github-release.tar.bz2 -C /tmp/ && sudo mv /tmp/bin/darwin/amd64/github-release /usr/local/bin/github-release
+else
+  curl -sSL -o /tmp/github-release.tar.bz2 https://github.com/aktau/github-release/releases/download/v0.5.2/linux-amd64-github-release.tar.bz2
+  tar jxf /tmp/github-release.tar.bz2 -C /tmp/ && sudo mv /tmp/bin/linux/amd64/github-release /usr/local/bin/github-release
+fi
 
 echo "Publishing github-release"
 TAG=$(head -n 1 VERSION)


### PR DESCRIPTION
Detect the OS and download the right version of the GH release binary. 