### PR TITLE
s3-upload: allow uploading to buckets in any region

### DIFF
--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -3,7 +3,6 @@
 # Publishes content from source dir to an S3 bucket.
 #
 # - All source dir content is uploaded (recursively).
-# - The target bucket must be in region "us-east-1".
 # - Example s3 bucket URL format: s3://<bucket>/<etc>/
 # - Requires two env vars to be set, with access to the bucket:
 #       * AWS_ACCESS_KEY_ID
@@ -33,4 +32,4 @@ install_awscli
 echo "Uploading files to s3..."
 echo "\tSource: $SOURCE_DIR"
 echo "\tDesination: $S3_BUCKET_URL"
-aws s3 cp $SOURCE_DIR $S3_BUCKET_URL --recursive --acl "private" --region "us-east-1" --cache-control "max-age=31536000"
+aws s3 cp $SOURCE_DIR $S3_BUCKET_URL --recursive --acl "private" --cache-control "max-age=31536000"


### PR DESCRIPTION
The comments on this script said that the target bucket must be in region "us-east-1", but it actually worked even if the target bucket was in a different region.

I think the `s3 cp` command just ignores the region argument, so I removed it. 