### PR TITLE
ci-script for submitting tests and polling for the status

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -49,7 +49,7 @@ push_ecr_image(){
   ECR_URI=$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$REPO:$SHORT_SHA
   if image_exists $ECR_URI > /dev/null; then
       echo "ECR image exists, refusing to overwrite"
-      exit 1
+      return
   fi
   docker tag $ORG/$REPO:$SHORT_SHA $ECR_URI
   docker push $ECR_URI

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Submits an application to integration-testing-service
+#
+# Usage:
+#
+#   integration-test [TESTING_SERVICE_URL] [TESTING_SERVICE_USER] [TESTING_SERVICE_PASS] [APP_NAME] [[TESTS_TO_RUN]]
+#
+# Required circleci provided environment variables:
+#
+#  CIRCLE_PROJECT_REPONAME
+#  CIRCLE_PROJECT_USERNAME
+#  CIRCLE_BUILD_NUM
+#
+
+set -e
+
+if [ $# -ne 4 ] && [ $# -ne 5 ] && [ $# -ne 6 ]; then
+    echo "Incorrect number of arguments given. Expected at least 4, received $#"
+    echo "Usage: integration-test [TESTING_SERVICE_URL] [TESTING_SERVICE_USER] [TESTING_SERVICE_PASS] [APP_NAME] [[TESTS_TO_RUN]]"
+    exit 1
+fi
+
+# User supplied args
+TESTING_SERVICE_URL=$1
+TESTING_SERVICE_USER=$2
+TESTING_SERVICE_PASS=$3
+APP_NAME=$4
+# TESTS_TO_RUN gets a default value, if not specified
+TESTS_TO_RUN=${5:-latest}
+
+# Set automatically by CircleCI
+: ${CIRCLE_PROJECT_REPONAME?"Missing required env var"}
+REPO=$CIRCLE_PROJECT_REPONAME
+: ${CIRCLE_PROJECT_USERNAME?"Missing required env var"}
+USER=$CIRCLE_PROJECT_USERNAME
+: ${CIRCLE_BUILD_NUM?"Missing required env var"}
+BUILD_NUM=$CIRCLE_BUILD_NUM
+
+echo "Submitting to integration-testing-service..."
+SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
+  -w "%{http_code}" \
+  --output integration-tests.out \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\",\"teststorun\":\"$TESTS_TO_RUN\"}" \
+  $TESTING_SERVICE_URL)
+
+if [[ $SC -eq 200 ]]; then
+  echo "Successfully submitted to integration-testing-service"
+  JOB_ID=$(cat integration-tests.out | jq '.jobId')
+  rm -f integration-tests.out
+else
+  echo "Failed to submit tests to integration-testing-service"
+  echo "------------------------------------------------"
+  cat integration-tests.out
+  echo ""
+  echo "------------------------------------------------"
+  rm -f integration-tests.out
+  exit 1
+fi
+
+echo "Job ID: $JOB_ID"
+
+echo "Waiting 1 minute before polling"
+sleep 2m
+
+echo "Polling for test completion"
+
+MAX_POLLS=10
+for ((i=1;i<=MAX_POLLS;i++))
+do
+  sleep 30s
+  SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
+    -w "%{http_code}" \
+    --output integration-tests.out \
+    -H "Content-Type: application/json" \
+    -X GET \
+    "$TESTING_SERVICE_URL?JobID=$JOB_ID")
+  if [[ $SC -eq 200 ]]; then
+    echo "------------------------------------------------"
+    STATUS=$(cat integration-tests.out | jq '.status')
+    echo "Tests status: $STATUS"
+    if [[ $STATUS == '"succeeded"' ]]; then
+      rm -f integration-tests.out
+      exit 0
+    elif [[ $STATUS == '"systemError"' || $STATUS == '"testsFailed"' ]]; then
+      echo "------------------------------------------------"
+      cat integration-tests.out
+      echo ""
+      echo "------------------------------------------------"
+      rm -f integration-tests.out
+      exit 1
+    fi
+  else
+    echo "------------------------------------------------"
+    echo $SC
+  fi
+done
+
+echo "------------------------------------------------"
+echo "Tests still not finished, timing out"
+rm -f integration-tests.out
+exit 1


### PR DESCRIPTION
This submits a new test job via `circle-ci-integrations` and then repeatedly polls using the job ID to get the status of the tests, until they succeed, fail, or time out.

Currently is hitting a build of `circle-ci-integrations` that just returns dummy output.

Example `frontend-test` jobs:
- timeout: https://circleci.com/gh/Clever/cil-event-logs-service/297
- tests failed: https://circleci.com/gh/Clever/cil-event-logs-service/301
- tests succeeded: https://circleci.com/gh/Clever/cil-event-logs-service/302

Example workflows:
- failed: https://circleci.com/workflow-run/3f95c136-07d5-4d5c-99fd-5e5c52f5978d
- successful: https://circleci.com/workflow-run/cf321025-b9c8-4524-bd87-c3a1cd0f44e2

The sleep times and the number of polls are also pretty arbitrary, they could definitely be adjusted.

-----
Also added a fix for `docker-publish` to make it not fail on reruns. It's still doing unnecessary work, so we could move the `image_exists` check to before the build. But then it'll require another back and forth `ecr_login` which is kind of annoying. Also not sure if it's worth optimizing for the case of reruns.