### PR TITLE
s3-upload give tips on how to find AWS id/secret

### DIFF
--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -7,6 +7,7 @@
 # - Requires two env vars to be set, with access to the bucket:
 #       * AWS_ACCESS_KEY_ID
 #       * AWS_SECRET_ACCESS_KEY
+# - If not set, check the associated IAM user for the id, and `ark secrets read production.[APP] ci-aws-secret` for the secret
 #
 # Usage:
 #


### PR DESCRIPTION
Came up through https://clever.slack.com/archives/C08G6CNMN/p1585183028041900

We have some IAM users that are used by CircleCI for uploading files to S3, e.g. https://github.com/Clever/infra/blob/master/config/aws/iam/prod/application_users.tf#L102-L134
https://github.com/Clever/infra/blob/master/config/aws/iam/prod/application_users.tf#L167-L177

We can easily look up the ID if we know to, e.g. https://console.aws.amazon.com/iam/home?region=us-west-2#/users/ci?section=security_credentials

But you can't view the secret once it's been created.

So let's put it in our secret store, and also leave some tips here for anyone who runs into this in the future.