### PR TITLE
Fixes for productionizing

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -48,7 +48,7 @@ SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
 
 if [[ $SC -eq 200 ]]; then
   echo "Successfully submitted to integration-testing-service"
-  JOB_ID=$(cat integration-tests.out | jq '.jobId')
+  JOB_ID=$(cat integration-tests.out | jq -r '.jobId')
   rm -f integration-tests.out
 else
   echo "Failed to submit tests to integration-testing-service"
@@ -63,11 +63,13 @@ fi
 echo "Job ID: $JOB_ID"
 
 echo "Waiting 1 minute before polling"
-sleep 2m
+sleep 1m
 
 echo "Polling for test completion"
 
-MAX_POLLS=10
+# Polling 20 times at 30 seconds each (10 minutes) for now, while integration-testing-service is not fully optimized
+# Should be tuned and lowered once jobs run more quickly.
+MAX_POLLS=20
 for ((i=1;i<=MAX_POLLS;i++))
 do
   sleep 30s

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -78,6 +78,7 @@ do
     --output integration-tests.out \
     -H "Content-Type: application/json" \
     -X GET \
+    -s -S \
     "$TESTING_SERVICE_URL?JobID=$JOB_ID")
   if [[ $SC -eq 200 ]]; then
     echo "------------------------------------------------"
@@ -86,7 +87,15 @@ do
     if [[ $STATUS == '"succeeded"' ]]; then
       rm -f integration-tests.out
       exit 0
-    elif [[ $STATUS == '"systemError"' || $STATUS == '"testsFailed"' ]]; then
+    elif [[ $STATUS == '"testsFailed"' ]]; then
+      # in this case, .message is a single JSON string encoding a JSON blob of the test output
+      echo "------------------------------------------------"
+      echo "Test output:"
+      cat integration-tests.out | jq -r '.message' | jq
+      echo "------------------------------------------------"
+      rm -f integration-tests.out
+      exit 1
+    elif [[ $STATUS == '"systemError"' ]]; then
       echo "------------------------------------------------"
       cat integration-tests.out
       echo ""


### PR DESCRIPTION
* Get jobID without quotes. 
* Bump test timeout to 11 minutes. This can and probably should be decreased later on, but since I'm initially going to not block deploy on integration test, and will just be making sure things are working, I would rather avoid timeouts.

The API this script is interacting with is set at https://github.com/Clever/circle-ci-integrations/pull/62

Example: https://app.circleci.com/pipelines/github/Clever/launchpad/6/workflows/18d3caa5-e9a4-400b-b8f1-814f43b5c741/jobs/12437
