### PR TITLE
Add ability to gzip files before uploading them to S3

### DIFF
--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -5,32 +5,64 @@
 # - All source dir content is uploaded (recursively).
 # - Example s3 bucket URL format: s3://<bucket>/<etc>/
 # - Requires two env vars to be set, with access to the bucket:
-#       * AWS_ACCESS_KEY_ID
-#       * AWS_SECRET_ACCESS_KEY
+#     * AWS_ACCESS_KEY_ID
+#     * AWS_SECRET_ACCESS_KEY
 # - If not set, import them from another app that uploads to the same bucket https://circleci.com/gh/Clever/[APP_NAME]/edit#env-vars
+# - If `--content-encoding gzip` is specified:
+#     * Files will be individually gzipped.
+#     * File names will not be changed (i.e. they will not be extended with .gz).
+#     * Files will all be tagged with `Content-Encoding: gzip` metadata in S3.
+#     * The original source dir content will be left unchanged.
 #
 # Usage:
 #
-#   s3-upload [SOURCE_DIR] [S3_BUCKET_URL]
+#   s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL
 
 set -e
 
 DIR=$(dirname "$0")
 . $DIR/utils
 
-if [ $# -ne 2 ]; then
-    echo "Incorrect number of arguments given. Expected 2, received $#"
-    echo "Usage: s3-upload [SOURCE_DIR] [S3_BUCKET_URL]"
+USAGE="Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL"
+WORK_DIR="/tmp/s3-upload/work-dir"
+
+if [[ $# -eq 4 ]]; then
+    if [[ $1 != "--content-encoding" ]]; then
+        echo "$USAGE"
+        exit 1
+    fi
+    if [[ $2 != "gzip" ]]; then
+        echo "Valid values for --content-encoding are: gzip"
+        echo "$USAGE"
+        exit 1
+    fi
+    CONTENT_ENCODING=$2
+    SOURCE_DIR=$3
+    S3_BUCKET_URL=$4
+elif [[ $# -eq 2 ]]; then
+    SOURCE_DIR=$1
+    S3_BUCKET_URL=$2
+else
+    echo "$USAGE"
     exit 1
 fi
 
-# User supplied args
-SOURCE_DIR=$1
-S3_BUCKET_URL=$2
+DIR_TO_UPLOAD="$SOURCE_DIR"
+ADDITIONAL_S3_FLAGS=""
+
+if [[ $CONTENT_ENCODING == "gzip" ]]; then
+    rm -rf $WORK_DIR
+    mkdir -p $WORK_DIR
+    cp -r $SOURCE_DIR $WORK_DIR
+    find $WORK_DIR -type f -exec gzip {} \; -exec mv {}.gz {} \;
+
+    DIR_TO_UPLOAD="$WORK_DIR/$(basename $SOURCE_DIR)"
+    ADDITIONAL_S3_FLAGS='--content-encoding gzip'
+fi
 
 install_awscli
 
-echo "Uploading files to s3..."
-echo "\tSource: $SOURCE_DIR"
-echo "\tDesination: $S3_BUCKET_URL"
-aws s3 cp $SOURCE_DIR $S3_BUCKET_URL --recursive --acl "private" --cache-control "max-age=31536000"
+echo "Uploading files to S3..."
+echo "  Source: $SOURCE_DIR"
+echo "  Desination: $S3_BUCKET_URL"
+aws s3 cp $DIR_TO_UPLOAD $S3_BUCKET_URL --recursive --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS

--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -54,7 +54,7 @@ if [[ $CONTENT_ENCODING == "gzip" ]]; then
     rm -rf $WORK_DIR
     mkdir -p $WORK_DIR
     cp -r $SOURCE_DIR $WORK_DIR
-    find $WORK_DIR -type f -exec gzip {} \; -exec mv {}.gz {} \;
+    find $WORK_DIR -type f -exec gzip --best {} \; -exec mv {}.gz {} \;
 
     DIR_TO_UPLOAD="$WORK_DIR/$(basename $SOURCE_DIR)"
     ADDITIONAL_S3_FLAGS='--content-encoding gzip'


### PR DESCRIPTION
# Overview

This PR introduces a `--content-encoding gzip` flag to the `s3-upload` script. If specified,

* Files will be individually gzipped.
* File names will not be changed (i.e. they will not be extended with .gz).
* Files will all be tagged with `Content-Encoding: gzip` metadata in S3.
* The original source dir content will be left unchanged.

See [this AWS support ticket](https://console.aws.amazon.com/support/home?region=us-west-1#/case/?displayId=6923462101&language=en) for the motivation behind this. tldr: CloudFront doesn't consistently compress assets so we're looking into uploading compressed assets to our origin S3 server to guarantee compression for end users.

# Testing

## Input validation

_Number of params_

```
$ ./circleci/s3-upload
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL

$ ./circleci/s3-upload source/
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL

$ ./circleci/s3-upload source/ destination/ extra
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL

$ ./circleci/s3-upload --content-encoding source/ destination/
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL

$ ./circleci/s3-upload --content-encoding gzip source/ destination/ extra
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL
```

_Invalid flags_

```
$ ./circleci/s3-upload --asdfasdf gzip source/ destination/
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL

$ ./circleci/s3-upload --content-encoding whoa source/ destination/
Valid values for --content-encoding are: gzip
Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL
```

_Valid_

```
$ ./circleci/s3-upload --content-encoding gzip source/ destination/
...

$ ./circleci/s3-upload source/ destination/
...
```

## Without `--content-encoding gzip` (existing behavior)

```
build
├── rando.txt
├── scripts
│   ├── a.js
│   └── b.js
└── styles
    ├── c.css
    └── d.css
```

```
arsalan@macbook:ci-scripts$ ./circleci/s3-upload build s3://assets.clever.com-dev/compression-testing
AWS cli already installed
Uploading files to S3...
  Source: build
  Desination: s3://assets.clever.com-dev/compression-testing
upload: build/rando.txt to s3://assets.clever.com-dev/compression-testing/rando.txt
upload: build/scripts/b.js to s3://assets.clever.com-dev/compression-testing/scripts/b.js
upload: build/styles/c.css to s3://assets.clever.com-dev/compression-testing/styles/c.css
upload: build/styles/d.css to s3://assets.clever.com-dev/compression-testing/styles/d.css
upload: build/scripts/a.js to s3://assets.clever.com-dev/compression-testing/scripts/a.js
```

<img width="1000" alt="1-uploaded" src="https://user-images.githubusercontent.com/12616928/78723065-9620e600-78df-11ea-9073-1452169759bd.png">

<img width="1000" alt="2-metadata" src="https://user-images.githubusercontent.com/12616928/78723068-96b97c80-78df-11ea-8ede-e6629900aa63.png">

<img width="1000" alt="3-network" src="https://user-images.githubusercontent.com/12616928/78723069-96b97c80-78df-11ea-99f7-305c99db7e60.png">

## With `--content-encoding gzip` (new behavior)

```
build
├── rando.txt
├── scripts
│   ├── a.js
│   └── b.js
└── styles
    ├── c.css
    └── d.css
```

```
arsalan@macbook:ci-scripts$ ./circleci/s3-upload --content-encoding gzip build s3://assets.clever.com-dev/compression-testing
AWS cli already installed
Uploading files to S3...
  Source: build
  Desination: s3://assets.clever.com-dev/compression-testing
upload: ../../../../../../../tmp/s3-upload/work-dir/build/scripts/a.js to s3://assets.clever.com-dev/compression-testing/scripts/a.js
upload: ../../../../../../../tmp/s3-upload/work-dir/build/styles/d.css to s3://assets.clever.com-dev/compression-testing/styles/d.css
upload: ../../../../../../../tmp/s3-upload/work-dir/build/styles/c.css to s3://assets.clever.com-dev/compression-testing/styles/c.css
upload: ../../../../../../../tmp/s3-upload/work-dir/build/scripts/b.js to s3://assets.clever.com-dev/compression-testing/scripts/b.js
upload: ../../../../../../../tmp/s3-upload/work-dir/build/rando.txt to s3://assets.clever.com-dev/compression-testing/rando.txt
```
<img width="1000" alt="4-uploaded" src="https://user-images.githubusercontent.com/12616928/78723208-e435e980-78df-11ea-878a-fdd7529cea8e.png">

<img width="1000" alt="5-metadata" src="https://user-images.githubusercontent.com/12616928/78723328-17787880-78e0-11ea-9b84-c22c02e2d271.png">

<img width="1000" alt="6-network" src="https://user-images.githubusercontent.com/12616928/78723333-19dad280-78e0-11ea-85f1-66ca474ba44e.png">

Also verified that the source files were left unchanged (uncompressed).

## Interaction with CloudFront

Uploaded assets using `--contend-encoding gzip` to s3://assets.clever.com. Verified that the CDN (https://assets.clever.com) served the assets correctly, compressed without double compressing.

# Rollout

This change is backwards compatible, so no existing repos should see an immediate change in behavior. I plan to use this new behavior to upload compressed assets to S3 for FamPo.