### PR TITLE
Update s3-upload to support individual file uploads

### DIFF
--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Publishes content from source dir to an S3 bucket.
+# Publishes a source directory or file to an S3 bucket.
 #
-# - All source dir content is uploaded (recursively).
-# - Example s3 bucket URL format: s3://<bucket>/<etc>/
+# - If the source is a directory, all its contents will be uploaded recursively
+# - Example S3 bucket URL format: s3://<bucket>/<etc>/
 # - Requires two env vars to be set, with access to the bucket:
 #     * AWS_ACCESS_KEY_ID
 #     * AWS_SECRET_ACCESS_KEY
@@ -16,14 +16,14 @@
 #
 # Usage:
 #
-#   s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL
+#   s3-upload [--content-encoding gzip] SOURCE_DIR_OR_FILE S3_BUCKET_URL
 
 set -e
 
 DIR=$(dirname "$0")
 . $DIR/utils
 
-USAGE="Usage: s3-upload [--content-encoding gzip] SOURCE_DIR S3_BUCKET_URL"
+USAGE="Usage: s3-upload [--content-encoding gzip] SOURCE_DIR_OR_FILE S3_BUCKET_URL"
 WORK_DIR="/tmp/s3-upload/work-dir"
 
 if [[ $# -eq 4 ]]; then
@@ -37,32 +37,36 @@ if [[ $# -eq 4 ]]; then
         exit 1
     fi
     CONTENT_ENCODING=$2
-    SOURCE_DIR=$3
+    SOURCE_DIR_OR_FILE=$3
     S3_BUCKET_URL=$4
 elif [[ $# -eq 2 ]]; then
-    SOURCE_DIR=$1
+    SOURCE_DIR_OR_FILE=$1
     S3_BUCKET_URL=$2
 else
     echo "$USAGE"
     exit 1
 fi
 
-DIR_TO_UPLOAD="$SOURCE_DIR"
+DIR_OR_FILE_TO_UPLOAD="$SOURCE_DIR_OR_FILE"
 ADDITIONAL_S3_FLAGS=""
+
+if [[ -d $SOURCE_DIR_OR_FILE ]]; then
+    ADDITIONAL_S3_FLAGS="--recursive"
+fi
 
 if [[ $CONTENT_ENCODING == "gzip" ]]; then
     rm -rf $WORK_DIR
     mkdir -p $WORK_DIR
-    cp -r $SOURCE_DIR $WORK_DIR
+    cp -r $SOURCE_DIR_OR_FILE $WORK_DIR
     find $WORK_DIR -type f -exec gzip --best {} \; -exec mv {}.gz {} \;
 
-    DIR_TO_UPLOAD="$WORK_DIR/$(basename $SOURCE_DIR)"
-    ADDITIONAL_S3_FLAGS='--content-encoding gzip'
+    DIR_OR_FILE_TO_UPLOAD="$WORK_DIR/$(basename $SOURCE_DIR_OR_FILE)"
+    ADDITIONAL_S3_FLAGS="$ADDITIONAL_S3_FLAGS --content-encoding gzip"
 fi
 
 install_awscli
 
 echo "Uploading files to S3..."
-echo "  Source: $SOURCE_DIR"
+echo "  Source: $SOURCE_DIR_OR_FILE"
 echo "  Desination: $S3_BUCKET_URL"
-aws s3 cp $DIR_TO_UPLOAD $S3_BUCKET_URL --recursive --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
+aws s3 cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS


### PR DESCRIPTION
# Overview

I recently discovered that the s3-upload script only supports directory uploads. When providing it an individual file to upload, it treats that file as a directory.

<img width="1148" alt="derp" src="https://user-images.githubusercontent.com/12616928/79266587-a7707200-7e4c-11ea-8424-4ab1ae0e3b4e.png">

This PR updates the script to handle both directories and files.

# Testing

- [x] Uploaded a directory successfully
- [x] Uploaded a file successfully
- [x] Uploaded a directory with `--content-encoding gzip` successfully
- [x] Uploaded a file with `--content-encoding gzip` successfully

For both `--content-encoding gzip` tests, I confirmed that the content was actually gzipped.

# Rollout

:100: