### PR TITLE
prepend v to versions, to support go mod

### DIFF
--- a/circleci/github-release
+++ b/circleci/github-release
@@ -42,6 +42,7 @@ fi
 
 echo "Publishing github-release"
 TAG=$(head -n 1 VERSION)
+if [[ ${str:0:1} != "v" ]]; then TAG=v$TAG; fi
 DESCRIPTION=$(tail -n +2 VERSION)
 
 result=$(github-release release -u $USER -r $REPO -t $TAG -n "$TAG" -d "$DESCRIPTION" -s $GITHUB_TOKEN $PRE_RELEASE || true)


### PR DESCRIPTION
go mod doesn't work with versions that don't have `v` as a prefix, since it's not technically official semver

I'll revert this change https://github.com/Clever/catapult/pull/1008/files

Makes more sense to put this in `github-release` rather than in every repo.