### PR TITLE
Bump integration test timeout to match the actual workflow timeout

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -67,9 +67,10 @@ sleep 1m
 
 echo "Polling for test completion"
 
-# Polling 20 times at 30 seconds each (10 minutes) for now, while integration-testing-service is not fully optimized
-# Should be tuned and lowered once jobs run more quickly.
-MAX_POLLS=20
+# Polling 60 times at 30 seconds each (30 minutes)
+# The timeout for the workflow is at 30 minutes, minus reserved time for cleanup.
+# Since we aren't planning on canceling the workflow on any shorter timeout, we should poll for that long.
+MAX_POLLS=60
 for ((i=1;i<=MAX_POLLS;i++))
 do
   sleep 30s


### PR DESCRIPTION
Timeout of the integration testing workflow itself is 30 minutes: https://github.com/Clever/integration-testing-service/blob/master/workflow/definitions.yml#L6

It's super not great if it's actually taking 30 minutes, but I don't know if there's much of a point bailing earlier inside `ci-scripts` unless we were actually planning on cancelling the running workflow.