### PR TITLE
add retries to catapult-publish steps

### DIFF
--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -35,6 +35,7 @@ BUILD_NUM=$CIRCLE_BUILD_NUM
 
 echo "Publishing to catapult..."
 SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \
+  --retry 5 \
   -w "%{http_code}" \
   --output catapult.out \
   -H "Content-Type: application/json" \

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -67,6 +67,7 @@ fi
 # publish the application to catapult
 echo "Publishing to catapult..."
 SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \
+          --retry 5 \
           -w "%{http_code}" \
           --output catapult.out \
           -H "Content-Type: application/json" \

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -56,6 +56,7 @@ AWS_REGION=$AWS_REGION \
 # publish the application to catapult
 echo "Publishing to catapult..."
 SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \
+          --retry 5 \
           -w "%{http_code}" \
           --output catapult.out \
           -H "Content-Type: application/json" \


### PR DESCRIPTION
retries have exponential backoff: 1s, 2s, 4s, 8s, 16s

Curl docs for --retry
https://curl.haxx.se/docs/manpage.html

```
If a transient error is returned when curl tries to perform a transfer, it will retry this number of times before giving up. Setting the number to 0 makes curl do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408 or 5xx response code.

When curl is about to retry a transfer, it will first wait one second and then for all forthcoming retries it will double the waiting time until it reaches 10 minutes which then will be the delay between the rest of the retries. By using --retry-delay you disable this exponential backoff algorithm. See also --retry-max-time to limit the total time allowed for retries.

Since curl 7.66.0, curl will comply with the Retry-After: response header if one was present to know when to issue the next retry.

If this option is used several times, the last one will be used.

Added in 7.12.3.
```