### PR TITLE
Add script to check that 'make generate' has been run

### DIFF
--- a/circleci/check-make-generate
+++ b/circleci/check-make-generate
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Checks that 'make generate' has been run by running it and checking for diffs.
+#
+# Usage:
+#
+#   check-make-generate
+
+set -e
+
+USAGE="Usage: check-make-generate"
+
+if [[ "$#" -ne 0 ]]; then
+  echo "$USAGE"
+  exit 1
+fi
+
+echo "Running 'make generate' and checking for diffs..."
+
+make generate > /dev/null
+
+if git diff --quiet --exit-code ; then
+  echo "Found no diffs. 'make generate' has been run."
+  exit 0;
+else
+  echo "Found diffs. Please run 'make generate'."
+  exit 1;
+fi

--- a/circleci/check-make-generate
+++ b/circleci/check-make-generate
@@ -19,10 +19,10 @@ echo "Running 'make generate' and checking for diffs..."
 
 make generate > /dev/null
 
-if git diff --quiet --exit-code ; then
+if git diff --quiet --exit-code; then
   echo "Found no diffs. 'make generate' has been run."
-  exit 0;
+  exit 0
 else
   echo "Found diffs. Please run 'make generate'."
-  exit 1;
+  exit 1
 fi


### PR DESCRIPTION
# Overview

This PR adds a script to check that `make generate` has been run. It accomplishes this by running `make generate` and checking for diffs, using `git diff`.

While it's hard to miss running `make generate` in WAG repos because you need the generated models, we also use `make generate` in FamPo for a number of purposes, including GraphQL code generation and translation file generation. The latter is particularly easy to miss; `make generate` must be run any time we add any new UI strings. And if it isn't run, nothing will fail. Using this script in FamPo's CircleCI build process will help guarantee that it's run for this case.

FamPo is currently using an [in-repo script](https://github.com/Clever/family-portal/blob/2c628efbc607c113f4e085c98d16e5634eb0642f/scripts/checkMakeGenerate.sh#L1-L16) for this purpose. I want to replace it with this shared script so that I can use it in other repos where we also translate, oauth for example.

# Testing

- [x] Verified that the script succeeds when `make generate` has been run

```
arsalan@macbook:family-portal$ ../ci-scripts/circleci/check-make-generate 
Running 'make generate' and checking for diffs...
Found no diffs. 'make generate' has been run.
```

- [x] Verified that the script errs when `make generate` hasn't been run but should have been

```
arsalan@macbook:family-portal$ ../ci-scripts/circleci/check-make-generate 
Running 'make generate' and checking for diffs...
Found diffs. Please run 'make generate'.
```

- [x] Verified that `git` commands can be used in CircleCI