### PR TITLE
Update check-make-generate

### DIFF
--- a/circleci/check-make-generate
+++ b/circleci/check-make-generate
@@ -10,6 +10,14 @@ set -e
 
 USAGE="Usage: check-make-generate"
 
+# Files to ignore when checking for diffs
+# TODO: Consider allowing consumers to specify additional files
+FILES_TO_IGNORE=(
+  ".npmrc"
+  ".npmrc_docker"
+  ".npmrc_docker.bak"
+)
+
 if [[ "$#" -ne 0 ]]; then
   echo "$USAGE"
   exit 1
@@ -19,10 +27,26 @@ echo "Running 'make generate' and checking for diffs..."
 
 make generate > /dev/null
 
-if git diff --quiet --exit-code; then
+# 'git status --porcelain' lists modified files as well as untracked (i.e. newly created) files in
+# a format that is guaranteed to be consistent, making the command ideal for scripting. File names
+# always begin at the fourth character of each line, hence the 'cut -c 4-'.
+diffFiles=$(git status --porcelain | cut -c 4-)
+for fileToIgnore in "${FILES_TO_IGNORE[@]}"; do
+  # Remove each fileToIgnore from the list. Use -F and -x to perform exact line matching rather
+  # than regex matching. Add an '|| echo ""' fallback because grep returns with an error when no
+  # lines are matched, causing the script to fail without the fallback.
+  diffFiles=$(echo "$diffFiles" | grep -Fvx "$fileToIgnore" || echo "")
+done
+
+if [[ -n "$diffFiles" ]]; then
+  echo ""
+  echo "Found diffs involving the following files:"
+  echo ""
+  echo "$diffFiles"
+  echo ""
+  echo "Please run 'make generate'."
+  exit 1
+else
   echo "Found no diffs. 'make generate' has been run."
   exit 0
-else
-  echo "Found diffs. Please run 'make generate'."
-  exit 1
 fi

--- a/circleci/check-make-generate
+++ b/circleci/check-make-generate
@@ -4,23 +4,24 @@
 #
 # Usage:
 #
-#   check-make-generate
+#   check-make-generate --files-to-ignore file1,file2,...,fileN
 
 set -e
 
-USAGE="Usage: check-make-generate"
+USAGE="Usage: check-make-generate --files-to-ignore file1,file2,...,fileN"
 
-# Files to ignore when checking for diffs
-# TODO: Consider allowing consumers to specify additional files
-FILES_TO_IGNORE=(
-  ".npmrc"
-  ".npmrc_docker"
-  ".npmrc_docker.bak"
-)
-
-if [[ "$#" -ne 0 ]]; then
+if [[ "$#" -ne 0 && "$#" -ne 2 ]]; then
   echo "$USAGE"
   exit 1
+fi
+
+declare -a FILES_TO_IGNORE
+if [[ "$#" -eq 2 ]]; then
+  if [[ "$1" != "--files-to-ignore" ]]; then
+    echo "$USAGE"
+    exit 1
+  fi
+  IFS="," read -a FILES_TO_IGNORE <<< "$2"
 fi
 
 echo "Running 'make generate' and checking for diffs..."


### PR DESCRIPTION
# Jira

[FAMBAM-579](https://clever.atlassian.net/browse/FAMBAM-579)

# Overview

https://github.com/Clever/ci-scripts/pull/78 introduced a new `check-make-generate` script to check that `make generate` has been run. See [that PR](https://github.com/Clever/ci-scripts/pull/78) for more context.

@taylor-sutton raised a great point in that PR:

> if an earlier CI command causes a git diff, this will fail; ... But we can deal with such issues as they arise

Turns out, we have a very common CI command that causes a git diff 😅

```
name: Set up .npmrc
command: |
  sed -i.bak s/\${npm_auth_token}/$NPM_TOKEN/ .npmrc_docker
  mv .npmrc_docker .npmrc
```

~This PR updates the script to ignore diffs from a list of `FILES_TO_IGNORE`. The list currently includes the files modified/created by the above command: `.npmrc`, `.npmrc_docker`, and `.npmrc_docker.bak`. As a follow-up, we could allow consumers to specify additional files to ignore.~

Update: This PR adds a `--files-to-ignore` option. But we aren't using it to address the `.npmrc` / `.npmrc_docker` / `.npmrc_docker.bak` issues. We're addressing those by updating the `.gitignore` and relevant CI command in consumer repos.

While working on the above, I also realized that the first iteration of the script was only checking for modified files, not newly created files. Because `make generate` can generate new files, it's important that we also check for those. This PR addresses this as well.

# Testing

- [x] Verified that the script ignores `.npmrc`, `.npmrc_docker`, and `.npmrc_docker.bak`

```
arsalan@macbook:family-portal$ git status
On branch ci-testing
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    .npmrc_docker

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.npmrc
	.npmrc_docker.bak

no changes added to commit (use "git add" and/or "git commit -a")
```
```
arsalan@macbook:family-portal$ ../ci-scripts/circleci/check-make-generate 
Running 'make generate' and checking for diffs...
Found no diffs. 'make generate' has been run.
```

- [x] Verified that the script errs when `make generate` hasn't been run but would've _modified_ files if it had been

```
arsalan@macbook:family-portal$ ../ci-scripts/circleci/check-make-generate 
Running 'make generate' and checking for diffs...

Found diffs involving the following files:

src/ui/translations/en.main.json
src/ui/translations/es.main.json
src/ui/translations/fil.main.json
src/ui/translations/ko.main.json
src/ui/translations/vi.main.json
src/ui/translations/zh.main.json

Please run 'make generate'.
```

- [x] Verified that the script errs when `make generate` hasn't been run but would've _created_ files if it had been

```
arsalan@macbook:family-portal$ ../ci-scripts/circleci/check-make-generate 
Running 'make generate' and checking for diffs...

Found diffs involving the following files:

src/ui/translations/fr.main.json

Please run 'make generate'.
```

- [x] Verified that the script works in the CI context by swapping out the contents of [Clever/family-portal/scripts/checkMakeGenerate.sh](https://github.com/Clever/family-portal/blob/59d0877f38f529b3bdb140eb85f5e40ff465695c/scripts/checkMakeGenerate.sh) with the contents of this PR

<img width="1140" alt="success" src="https://user-images.githubusercontent.com/12616928/96216946-690c5a80-0f36-11eb-8db8-4b2f2b0e9f95.png">

<img width="1140" alt="fail" src="https://user-images.githubusercontent.com/12616928/96216964-74f81c80-0f36-11eb-9015-7bd2b4f75850.png">

- [x] Verified that the grep call performs exact matching as desired

# Rollout

:100: