### PR TITLE
Use AWS CLI v2

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -41,7 +41,8 @@ check_ecr_vars() {
 
 ecr_login(){
   REGION=$1
-  eval $(AWS_ACCESS_KEY_ID=$2 AWS_SECRET_ACCESS_KEY=$3 aws ecr --region $REGION get-login --include-email) || eval $(AWS_ACCESS_KEY_ID=$2 AWS_SECRET_ACCESS_KEY=$3 aws ecr --region $REGION get-login --no-include-email)
+  ECR_REPO=$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+  AWS_ACCESS_KEY_ID=$2 AWS_SECRET_ACCESS_KEY=$3 aws ecr --region $REGION get-login-password | docker login --username AWS --password-stdin $ECR_REPO
 }
 
 push_ecr_image(){

--- a/circleci/utils
+++ b/circleci/utils
@@ -15,14 +15,8 @@ install_awscli(){
   fi
 
   echo "Installing AWS cli..."
-  rm -rf ~/.local
-  wget --directory-prefix=/tmp/ https://bootstrap.pypa.io/get-pip.py
-  sudo python /tmp/get-pip.py
-
-  sudo apt-get update
-  sudo apt-get install python-dev
-  sudo pip install --upgrade awscli && aws --version
-
-  pip install --upgrade --user awscli
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+  unzip -q /tmp/awscliv2.zip -d /tmp
+  sudo /tmp/aws/install
   echo "Completed AWS cli install"
 }


### PR DESCRIPTION
JIRA: https://clever.atlassian.net/browse/INFRANG-4330

Following instructions to install at https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html

As far as I can tell, none of the [v2 breaking changes](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html) are relevant to how we use AWS CLI in CircleCI *except* the `docker login` one, which is changed here.

Doing it this way removes any dependency on `pip` and `python` in this stack, which is actually great because the newest version of `pip` (the one that's installed by that `wget get-pip.py`) dropped support for Python 2, and was causing errors. We could switch the line that installs Python to install Python 3 instead, but this seemed like a good place to switch to the new CLI, which is faster to install anyway.

As a sanity check I ran CI with this branch of `ci-scripts` for both [a lambda](https://github.com/Clever/freezer/commit/d2d9ff7f8e195f18bbd69537deaff4ea8205be2a) and [oauth](https://github.com/Clever/oauth/commit/8a6a67eb3d37da218dcab8eabd769ee2a436f89b). I picked `oauth` because, besides being something that uses the `docker-publish` script that I changed, it also has some custom S3 stuff for uploading assets.

Without *some* change (either fixing the python 3 thing or switching to v2) we get [these](https://app.circleci.com/pipelines/github/Clever/freezer/106/workflows/6aa7012f-7434-4b34-b2db-ea088278014b/jobs/155) errors in CI when installing.