### PR TITLE
Update `integration-test` with new backend features.

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -27,7 +27,8 @@ TESTING_SERVICE_USER=$2
 TESTING_SERVICE_PASS=$3
 APP_NAME=$4
 # TESTS_TO_RUN gets a default value, if not specified
-TESTS_TO_RUN=${5:-latest}
+# It is a JSON value whose schema corresponds with our internal testing spec schema.
+TESTS_TO_RUN=${5:-"[{\"type\": \"launchpad\"}]"}
 
 # Set automatically by CircleCI
 : ${CIRCLE_PROJECT_REPONAME?"Missing required env var"}
@@ -43,7 +44,7 @@ SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
   --output integration-tests.out \
   -H "Content-Type: application/json" \
   -X POST \
-  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\",\"teststorun\":\"$TESTS_TO_RUN\"}" \
+  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\",\"tests\":\"$TESTS_TO_RUN\"}" \
   $TESTING_SERVICE_URL)
 
 if [[ $SC -eq 200 ]]; then

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -94,6 +94,8 @@ do
       echo "Test output:"
       cat integration-tests.out | jq -r '.message' | jq
       echo "------------------------------------------------"
+      ENV=$(jq .environment < integration-tests.out)
+      echo "Tests ran in staging environment: ${ENV:-<not sure>}"
       rm -f integration-tests.out
       exit 1
     elif [[ $STATUS == '"systemError"' ]]; then


### PR DESCRIPTION
Updates `integration-test` to match https://github.com/Clever/circle-ci-integrations/pull/135. The changes here are
- Expose the `environment` to the invoker of this script
- Change the schema for `TESTS_TO_RUN` and send it as `tests` instead of `teststorun` in JSON.

Currently, all of our existing projects leave out `$5`, so it is currently always getting set to the default (and thus is safe to change the way `$5` is used). And the backend was never reading the `teststorun` field, so it is safe to remove.