### PR TITLE
Hotfix string escaping.

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -28,7 +28,7 @@ TESTING_SERVICE_PASS=$3
 APP_NAME=$4
 # TESTS_TO_RUN gets a default value, if not specified
 # It is a JSON value whose schema corresponds with our internal testing spec schema.
-TESTS_TO_RUN=${5:-"[{\"type\": \"launchpad\"}]"}
+TESTS_TO_RUN=${5:-'[{\"type\": \"launchpad\"}]'}
 
 # Set automatically by CircleCI
 : ${CIRCLE_PROJECT_REPONAME?"Missing required env var"}


### PR DESCRIPTION
Saw errors in ci `{"message":"invalid character 't' after object key:value pair"}`: https://app.circleci.com/pipelines/github/Clever/launchpad/3288/workflows/32a3053a-a173-4fc8-bf22-40daa5cadf33/jobs/22469