### PR TITLE
Allow multiple comma-separated apps to be tested in one job.

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -17,7 +17,7 @@ set -e
 
 if [ $# -ne 4 ] && [ $# -ne 5 ] && [ $# -ne 6 ]; then
     echo "Incorrect number of arguments given. Expected at least 4, received $#"
-    echo "Usage: integration-test [TESTING_SERVICE_URL] [TESTING_SERVICE_USER] [TESTING_SERVICE_PASS] [APP_NAME] [[TESTS_TO_RUN]]"
+    echo "Usage: integration-test [TESTING_SERVICE_URL] [TESTING_SERVICE_USER] [TESTING_SERVICE_PASS] [APP_NAMES] [[TESTS_TO_RUN]]"
     exit 1
 fi
 
@@ -25,7 +25,8 @@ fi
 TESTING_SERVICE_URL=$1
 TESTING_SERVICE_USER=$2
 TESTING_SERVICE_PASS=$3
-APP_NAME=$4
+# APP_NAMES is a comma-separated list of applications e.g. app-service,sso-app-service
+APP_NAMES=$4
 # TESTS_TO_RUN gets a default value, if not specified
 # It is a JSON value whose schema corresponds with our internal testing spec schema.
 TESTS_TO_RUN=${5:-'[{"type": "launchpad"}]'}
@@ -38,13 +39,21 @@ USER=$CIRCLE_PROJECT_USERNAME
 : ${CIRCLE_BUILD_NUM?"Missing required env var"}
 BUILD_NUM=$CIRCLE_BUILD_NUM
 
+# Convert APP_NAMES (comma-separated list of apps e.g appA,appB) into a JSON array
+APPS=$(echo "${APP_NAMES}" |
+	   sed 's/,/\n/g' | # a,b,c => a\nb\nc
+	   jq --raw-input | # a\nb\nc => "a"\n"b"\n"c"\n ; raw-input means read the input as strings (one per line), not as JSON,
+	                    # but we still output as JSON, thus we add the quotes
+	   jq --slurp --compact-output # "a"\n"b"\n"c"\n => ["a","b","c"]  ; slurp to combine lines into a JSON array
+    )
+
 echo "Submitting to integration-testing-service..."
 SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
   -w "%{http_code}" \
   --output integration-tests.out \
   -H "Content-Type: application/json" \
   -X POST \
-  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\",\"tests\":${TESTS_TO_RUN}}" \
+  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"apps\":${APPS},\"tests\":${TESTS_TO_RUN}}" \
   $TESTING_SERVICE_URL)
 
 if [[ $SC -eq 200 ]]; then


### PR DESCRIPTION
The API for `circle-ci-integrations` was updated in https://github.com/Clever/circle-ci-integrations/pull/135 and now we can submit multiple apps at once in a streamlined way (and we can still pass a single app by just giving an array of length one). 

Apps aren't allowed to have commas or quotes in them, so this shouldn't break anything existing.

Tested in https://app.circleci.com/pipelines/github/Clever/family-media-center/2783/workflows/8741e6cc-91a7-43cc-8ae3-f7fbb1754819/jobs/2822

