### PR TITLE
Update docker-publish

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -5,7 +5,7 @@
 #
 # Usage:
 #
-#   docker-publish
+#   docker-publish -r private-repos
 
 
 set -e
@@ -22,6 +22,13 @@ else
     mkdir -p ~/.docker
     echo '{"experimental":"enabled"}' > ~/.docker/config.json
 fi
+
+readopt='none'
+while getopts 'r:' flag; do
+    case "${flag}" in
+        r) readopt=${OPTARG};;
+    esac
+done
 
 image_exists() {
     docker manifest inspect "$1" > /dev/null
@@ -83,8 +90,14 @@ echo "They can be found in init-service as CI_ECR_XXX_KEY and CI_ECR_XXX_SECRET.
 if [[ -n $ECR_BUILD_ID ]]; then
   ecr_login us-west-1 $ECR_BUILD_ID $ECR_BUILD_SECRET
 fi
-echo "Building docker image..."
-docker build -t $ORG/$REPO:$SHORT_SHA .
+
+echo "Building docker image..." 
+if [ $readopt == "private-repos" ]; then
+  echo "With Private Repos..."
+  DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
+else
+  docker build -t $ORG/$REPO:$SHORT_SHA .
+fi
 
 # ECR login.
 echo "Logging into ECR..."

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -5,7 +5,8 @@
 #
 # Usage:
 #
-#   docker-publish -r private-repos
+#   docker-publish 
+#   optional flag "-r private-repos" enables Docker Build Kit to allow ssh socket mounting to pull private modules/repos
 
 
 set -e


### PR DESCRIPTION
When building a go program that uses a private go module we need to be able to pull a private module in the build container. This change allows us to pass the `-r private-repos` flag to `docker-publish`. This mounts the ssh socket of the host system to allow the container to pull modules/git repos without having to add ssh keys and then remove them from the container.  This will allow all repos to be able to pull private modules during go build with setting this flag and tagging the `setup_remote_docker` [version](https://github.com/Clever/opentelemetry-lambda/blob/1278ae18108c46e6d455921f3858b2a7fcaf9d88/.circleci/config.yml#L31-L32).