### PR TITLE
Migrate to next-gen CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/Clever/ci-scripts
     docker:
-    - image: circleci/buildpack-deps:18.04
+    - image: cimg/base:stable
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results


### PR DESCRIPTION

The circleci/buildpack-deps image is deprecated and cimg/base is the suggested replacement
This PR migrates off of the deprecated previous-gen `circleci/buildpack-deps` image onto the suggested replacement `cimg/base`.

We are experimenting with NOT pinning the build image tag. Theoretically, this could cause a build that succeeds to fail if re-run later, after the tag moves. If necessary, the `stable` tag can be changed to `YYYY.MM` to pin to an immutable version.
