### PR TITLE
github workflow to automate approving and merging PRs

### DIFF
--- a/.github/workflows/auto-approve-merge.yml
+++ b/.github/workflows/auto-approve-merge.yml
@@ -1,0 +1,25 @@
+# Basic workflow that approves and enables auto merge for PRs. Currently only does this for dependabot PRs
+# https://app.getguru.com/card/cbjEdoAi/Dependabot-and-auto-merging
+
+name: Enable auto merge and then approve
+
+on: workflow_call
+
+jobs:
+  auto-approve-merge-dependency-updates:
+    name: Approve and Enable auto merge on dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+    # Use github cli to enable auto approve. Only works on repos which have auto merge enabled and branch protections setup which is currently blocking a merge
+    # for example still requires 1 review or a required ci step has not succeeded.
+    - name: Enable Automerge
+      run: gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # v2.1.0 as of 02/23/2022, reviewed by eng-security.
+    - name: Approve
+      uses: hmarr/auto-approve-action@5d04a5ca6da9aeb8ca9f31a5239b96fc3e003029
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-auto-approve-merge.yml
+++ b/.github/workflows/reusable-auto-approve-merge.yml
@@ -1,4 +1,5 @@
-# Basic workflow that approves and enables auto merge for PRs. Currently only does this for dependabot PRs
+# Basic workflow that approves and enables auto merge for PRs.
+# Currently it is used to automate merging dependabot PRs or overridining the required review on a PR
 # https://app.getguru.com/card/cbjEdoAi/Dependabot-and-auto-merging
 
 name: Enable auto merge and then approve
@@ -9,17 +10,18 @@ jobs:
   auto-approve-merge-dependency-updates:
     name: Approve and Enable auto merge on dependabot PRs
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
     # Use github cli to enable auto approve. Only works on repos which have auto merge enabled and branch protections setup which is currently blocking a merge
     # for example still requires 1 review or a required ci step has not succeeded.
-    - name: Enable Automerge
+    - if: github.actor == 'dependabot[bot]'
+      name: Enable Automerge
       run: gh pr merge --auto --merge "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # v2.1.0 as of 02/23/2022, reviewed by eng-security.
-    - name: Approve
+    - if: github.actor == 'dependabot[bot]' || contains( github.event.pull_request.labels.*.name, 'auto approve')
+      name: Approve
       uses: hmarr/auto-approve-action@5d04a5ca6da9aeb8ca9f31a5239b96fc3e003029
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**jira**: Passion week 

**Overview:**

- I added hmarr/auto-approve-action@5d04a5ca6da9aeb8ca9f31a5239b96fc3e003029 to be allowed at org level.
- Tested this with https://github.com/Clever/dependency-failure-diagram-generator/blob/master/.github/workflows/dependabot.yml workflow which is pretty straight forward
- Wrote a github card to explain how to set this up https://app.getguru.com/card/cbjEdoAi/Dependabot-and-auto-merging
- See me testing multiple different scenarios here! https://github.com/Clever/dependency-failure-diagram-generator/pull/219
  - PR says approved and merged by `github-actions`
- Coincidentally here is an example of when this doesn't work https://github.com/Clever/dependency-failure-diagram-generator/pull/220. The previous PR was merged after this was opened leading to merge conflicts. In reality this should be rare. If it is a big problem then we can use https://github.com/pascalgn/automerge-action instead of the `gh` cli
  - Even this case tho you can see that PR is approved and auto merge is enabled, we just need to say `@dependabot rebase` and it should work. 
- Finally here is the automated deployment!!!! https://clever.slack.com/archives/C0345BFU137/p1645727815460149 🥳 🥳 🥳 

**Rollout:**
- https://github.com/Clever/dependency-failure-diagram-generator/blob/master/.github/workflows/dependabot.yml#L10 should point to `master`