### PR TITLE
Wait for release

### DIFF
--- a/circleci/github-release
+++ b/circleci/github-release
@@ -71,7 +71,7 @@ while [ $SECONDS -lt $end ]; do
       sleep 5
       continue
     fi
-    echo -e "Check release response at $((SECONDS-now)) seconds after submitting request \n$check_release\n***"
+    echo -e "Release found at $((SECONDS-now)) seconds after submitting request \n$check_release\n***"
     release_created=true
     break
 done

--- a/circleci/github-release
+++ b/circleci/github-release
@@ -48,15 +48,36 @@ TAG=$(head -n 1 VERSION)
 if [[ ${TAG:0:1} != "v" ]]; then TAG=v$TAG; fi
 DESCRIPTION=$(tail -n +2 VERSION)
 
+# create a release and wait at most 60 seconds for it to be created
 export GITHUB_TOKEN=$GITHUB_TOKEN
-result=$($GITHUB_RELEASE release -u $USER -r $REPO -t $TAG -n "$TAG" -d "$DESCRIPTION" $PRE_RELEASE || true)
+result=$($GITHUB_RELEASE release -u $USER -r $REPO -t $TAG -n "$TAG" -d "$DESCRIPTION" $PRE_RELEASE 2>&1 || true)
+now=$SECONDS
+end=$((now+60))
 if [[ $result == *422* ]]; then
   echo "Release already exists for this tag.";
   exit 0
 elif [[ $result == "" ]]; then
-  echo "Release created.";
+  echo "Create release request submitted successfully.";
 else
   echo "Error creating release: $result"
+  exit 1
+fi
+
+release_created=false
+while [ $SECONDS -lt $end ]; do
+    check_release=$($GITHUB_RELEASE info -u $USER -r $REPO -t $TAG 2>&1 || true)
+    if [[ $check_release =~ "could not find the release" ]]; then
+      echo -e "Release not yet created at $((SECONDS-now)) seconds since submitting request: \n$check_release\n***"
+      sleep 5
+      continue
+    fi
+    echo -e "Check release response at $((SECONDS-now)) seconds after submitting request \n$check_release\n***"
+    release_created=true
+    break
+done
+
+if [ release_created = "false" ]; then
+  echo "error: $SECONDS seconds have passed since we submitted request to create release but it is not yet created"
   exit 1
 fi
 

--- a/circleci/github-release
+++ b/circleci/github-release
@@ -34,10 +34,10 @@ if [ ! -e VERSION ]; then echo "Missing VERSION file" && exit 1; fi
 echo "Downloading github-release tool"
 GITHUB_RELEASE=/usr/local/bin/github-release
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  curl -sSL -o /tmp/github-release.bz2 https://github.com/github-release/github-release/releases/download/v0.8.1/darwin-amd64-github-release.bz2
+  curl -sSL -o /tmp/github-release.bz2 https://github.com/github-release/github-release/releases/download/v0.10.0/darwin-amd64-github-release.bz2
   bunzip2 /tmp/github-release.bz2 && sudo mv /tmp/github-release $GITHUB_RELEASE
 else
- curl -sSL -o /tmp/github-release.bz2 https://github.com/github-release/github-release/releases/download/v0.8.1/linux-amd64-github-release.bz2
+ curl -sSL -o /tmp/github-release.bz2 https://github.com/github-release/github-release/releases/download/v0.10.0/linux-amd64-github-release.bz2
  bunzip2 /tmp/github-release.bz2 && sudo mv /tmp/github-release $GITHUB_RELEASE
 fi
 


### PR DESCRIPTION
oncall.
example error cases https://app.circleci.com/pipelines/github/Clever/ci-scripts/164/workflows/938a8bae-f413-4f55-adab-ecbce3df4c1c/jobs/344 and https://app.circleci.com/pipelines/github/Clever/ark/1043/workflows/e72834b5-bc26-40d5-9e47-df9b2738954b/jobs/2335

This started happening today (maybe this week 🤷)! 

- The first run of `github-release` is always failing with the error that release is not found. So let's update this script to check for release before proceeding to upload to said release.
- Also bump version of github-release tool to latest.

Testing:
```
Downloading github-release tool
Publishing github-release
Create release request submitted successfully.
Release not yet created at 3 seconds since submitting request: 
error: could not find the release corresponding to tag v0d5422a
***
Check release response at 10 seconds after submitting request 
tags:
- v0d5422a (commit: https://api.github.com/repos/Clever/ci-scripts/commits/bf3e025d2a7063269edd681ae93500b21c12a017)
releases:
- v0d5422a, name: 'v0d5422a', description: 'v0d5422a', id: 60439564, tagged: 24/02/2022 at 23:51, published: 25/02/2022 at 01:04, draft: ✗, prerelease: ✗
***
uploading foo.txt
CircleCI received exit code 0
```
:this: is output from the ci run on this branch.