### PR TITLE
Only run workflow if status is triggered by commit coming from a single branch

### DIFF
--- a/.github/workflows/reusable-notify-ci-status.yml
+++ b/.github/workflows/reusable-notify-ci-status.yml
@@ -23,6 +23,12 @@ jobs:
     name: Notify via Slack on CI status update
     runs-on: ubuntu-latest
     environment: production
+    # only run if this event is associated with a single branch, otherwise we aren't sure the branches[0].name is the one that triggered the event.
+    # this workflow is only fired from the calling repo when the branches[0].name is master, but if someone creates a new branch off master
+    # and pushes to origin without adding additional commits, master will be included in the array even though it wasn't the triggering branch.
+    # since merge/squash commits are almost always used upon merging to master, and are thus only associated with master at the time of
+    # merging, we should still capture all intended situation since len(branches) will == 1
+    if: github.event.branches[1] == null
     steps:
     - name: Notify
       uses: Clever/ci-scripts/.github/actions/notify-ci-status-action@master


### PR DESCRIPTION
On each status event, the CI-notify workflow checks if the status event.state is failed and if the `event.branches[0].name` is master, and in this case, we call this re-usable workflow. The `event.branches` field is the only way we can associate a status event with `master`, but it is an array because the event is associated with the commit, with `branches` as the array of branches that have the commit as the head. 

This is fine most of the time, but I knew there was a small chance we might need to refine the logic here. I didn't expect people to push to origin after branching from master without adding additional commits to a branch, but it turns out it happens occasionally. And in that case, the branches array can have multiple entries, with the first potentially being master, even if the CI status failure was triggered from a new branch.

I noticed this when somewhat branched off master for `website` then pushed, and their [build](https://app.circleci.com/pipelines/github/Clever/website/132/workflows/f591d391-40ff-4bea-ac89-9b38486a2f91) failed, and I got a message because I was the most recent commit author. 

This fix should address the issue, but in the future I might try to take a more robust approach where I examine other fields of the branch to find an association between the event and the branch that actually triggered the status event based on associated timestamps etc. 