### PR TITLE
drop support for lambda/<> and glue/<>

### DIFF
--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -33,14 +33,24 @@ USER=$CIRCLE_PROJECT_USERNAME
 : ${CIRCLE_BUILD_NUM?"Missing required env var"}
 BUILD_NUM=$CIRCLE_BUILD_NUM
 
+RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+if [[ $RUN_TYPE != "docker" ]]; then
+    echo "Can only publish applications with run type 'docker' using this script; got ${RUN_TYPE}"
+    exit 1
+fi
+
 echo "Publishing to catapult..."
+echo "Using data:"
+DATA="{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\"}"
+echo "${DATA}"
+echo "================================================================================"
 SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \
   --retry 5 \
   -w "%{http_code}" \
   --output catapult.out \
   -H "Content-Type: application/json" \
   -X POST \
-  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\"}" \
+  -d "${DATA}" \
   $CATAPULT_URL)
 
 if [ "$SC" -eq 200 ]; then

--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -15,6 +15,9 @@
 
 set -e
 
+DIR=$(dirname "$0")
+. $DIR/utils
+
 # User supplied args
 CATAPULT_URL=$1
 if [[ -z $CATAPULT_URL ]]; then echo "Missing arg1 CATAPULT_URL" && exit 1; fi
@@ -33,8 +36,10 @@ USER=$CIRCLE_PROJECT_USERNAME
 : ${CIRCLE_BUILD_NUM?"Missing required env var"}
 BUILD_NUM=$CIRCLE_BUILD_NUM
 
-RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
-if [[ $RUN_TYPE != "docker" ]]; then
+install_yq
+
+RUN_TYPE=$(yq '.run.type' "launch/${APP_NAME}.yml")
+if [[ $RUN_TYPE != "docker" && $RUN_TYPE != "null" ]]; then
     echo "Can only publish applications with run type 'docker' using this script; got ${RUN_TYPE}"
     exit 1
 fi

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -37,8 +37,9 @@ BRANCH=$CIRCLE_BRANCH
 : ${CATAPULT_PASS?"Missing required env var"}
 
 install_awscli
+install_yq
 
-RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+RUN_TYPE=$(yq '.run.type' "launch/${APP_NAME}.yml")
 if [[ $RUN_TYPE != "lambda" ]]; then
     echo "Can only publish applications with run type 'lambda' using this script; got ${RUN_TYPE}"
     exit 1

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -38,24 +38,16 @@ BRANCH=$CIRCLE_BRANCH
 
 install_awscli
 
-# Set RUN_TYPE, AWS_REGIONS, and S3_ARTIFACTS
-# If application's run type is lambda/<region>; AWS_REGIONS will be just that regions
-#    and S3_ARTIFACTS will set the S3Bucket source variable
-# If it is lambda (i.e. no region), AWS_REGIONS will be all four main US regions,
-#    and S3_ARTIFACTS will set the S3Buckets source variable
 RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
-if [[ $RUN_TYPE == "lambda/"* ]]; then
-    AWS_REGIONS=$(echo "${RUN_TYPE}" | cut -d'/' -f2)
-    S3_ARTIFACTS=",S3Bucket=\\\"${LAMBDA_AWS_BUCKET}-${AWS_REGIONS}"
-elif [[ $RUN_TYPE == "lambda" ]]; then
-    AWS_REGIONS=${AWS_REGIONS:-"us-east-1 us-east-2 us-west-1 us-west-2"}
-    for REGION in ${AWS_REGIONS}; do
-        S3_ARTIFACTS=${S3_ARTIFACTS},"S3Buckets={${REGION}=\\\"${LAMBDA_AWS_BUCKET}-${REGION}"
-    done
-else
-    echo "Can only publish applications with run type lambda or lambda/<region>; got ${RUN_TYPE}"
+if [[ $RUN_TYPE != "lambda" ]]; then
+    echo "Can only publish applications with run type 'lambda' using this script; got ${RUN_TYPE}"
     exit 1
 fi
+
+AWS_REGIONS="us-east-1 us-east-2 us-west-1 us-west-2"
+for REGION in ${AWS_REGIONS}; do
+    S3_ARTIFACTS=${S3_ARTIFACTS},"S3Buckets={${REGION}=\\\"${LAMBDA_AWS_BUCKET}-${REGION}"
+done
 
 CIRCLE_CI_INTEGRATIONS_URL=$(dirname $CATAPULT_URL)
 

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -15,9 +15,6 @@ DIR=$(dirname "$0")
 APP_NAME=$1
 if [[ -z $APP_NAME ]]; then echo "Missing arg1 APP_NAME" && exit 1; fi
 
-RUN_TYPE=$(grep type launch/${APP_NAME}.yml | cut -d' ' -f4)
-AWS_REGION=$(echo ${RUN_TYPE} | cut -d'/' -f2)
-
 # Set automatically by CircleCI
 : ${CIRCLE_PROJECT_REPONAME?"Missing required env var"}
 REPO=$CIRCLE_PROJECT_REPONAME
@@ -41,6 +38,16 @@ BRANCH=$CIRCLE_BRANCH
 
 install_awscli
 
+RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+if [[ $RUN_TYPE != "glue" ]]; then
+    echo "Can only publish applications with run type 'glue' using this script; got ${RUN_TYPE}"
+    exit 1
+fi
+
+# glue is only supported in us-west-2
+AWS_REGION="us-west-2"
+S3_ARTIFACTS=",S3Bucket=\\\"${GLUE_AWS_BUCKET}-${AWS_REGION}"
+
 CIRCLE_CI_INTEGRATIONS_URL=$(dirname $CATAPULT_URL)
 
 # hack to switch from /catapult to /v2/catapult
@@ -49,21 +56,24 @@ GLUE_AWS_S3_KEY=${APP_NAME}/${SHORT_SHA}
 
 # upload to s3
 echo "Uploading to S3..."
-# region doesn't really matter for an S3 upload, since the bucket region is fixed
 AWS_REGION=$AWS_REGION \
-          AWS_ACCESS_KEY_ID=$GLUE_AWS_ACCESS_KEY_ID \
-          AWS_SECRET_ACCESS_KEY=$GLUE_AWS_SECRET_ACCESS_KEY \
-          aws s3 cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
+        AWS_ACCESS_KEY_ID=$GLUE_AWS_ACCESS_KEY_ID \
+        AWS_SECRET_ACCESS_KEY=$GLUE_AWS_SECRET_ACCESS_KEY \
+        aws s3 cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
 
 # publish the application to catapult
 echo "Publishing to catapult..."
+echo "Using data:"
+DATA="{\"username\":\"${USER}\",\"reponame\":\"${REPO}\",\"buildnum\":${BUILD_NUM},\"app\":{\"run_type\":\"${RUN_TYPE}\",\"id\":\"${APP_NAME}\",\"source\":\"github:Clever/${REPO}@${FULL_SHA}\",\"artifacts\":\"glue:clever/${APP_NAME}@${SHORT_SHA};S3Key=\\\"${GLUE_AWS_S3_KEY}${S3_ARTIFACTS}\",\"branch\":\"${BRANCH}\"}}"
+echo "${DATA}"
+echo "================================================================================"
 SC=$(curl -u $CATAPULT_USER:$CATAPULT_PASS \
           --retry 5 \
           -w "%{http_code}" \
           --output catapult.out \
           -H "Content-Type: application/json" \
           -X POST \
-          -d "{\"username\":\"${USER}\",\"reponame\":\"${REPO}\",\"buildnum\":${BUILD_NUM},\"app\":{\"run_type\":\"${RUN_TYPE}\",\"id\":\"${APP_NAME}\",\"source\":\"github:Clever/${REPO}@${FULL_SHA}\",\"artifacts\":\"glue:clever/${APP_NAME}@${SHORT_SHA};S3Bucket=\\\"${GLUE_AWS_BUCKET}-${AWS_REGION},S3Prefix=\\\"${GLUE_AWS_S3_KEY}\",\"branch\":\"${BRANCH}\"}}" \
+          -d "${DATA}" \
           $CATAPULT_URL)
 
 if [ "$SC" -eq 200 ]; then

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -37,8 +37,9 @@ BRANCH=$CIRCLE_BRANCH
 : ${CATAPULT_PASS?"Missing required env var"}
 
 install_awscli
+install_yq
 
-RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+RUN_TYPE=$(yq '.run.type' "launch/${APP_NAME}.yml")
 if [[ $RUN_TYPE != "glue" ]]; then
     echo "Can only publish applications with run type 'glue' using this script; got ${RUN_TYPE}"
     exit 1

--- a/circleci/utils
+++ b/circleci/utils
@@ -20,3 +20,16 @@ install_awscli(){
   sudo /tmp/aws/install
   echo "Completed AWS cli install"
 }
+
+install_yq(){
+  if type yq > /dev/null; then
+    echo "yq already installed"
+    return
+  fi
+
+  echo "Installing yq..."
+  wget https://github.com/mikefarah/yq/releases/download/v4.24.5/yq_linux_amd64 -O /tmp/yq
+  sudo mv /tmp/yq /usr/local/bin/yq
+  sudo chmod +x /usr/local/bin/yq
+  echo "Compelted yq cli install"
+}


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRANG-4773

- improve logging for all 3 ways to publish catapult applications
- make publishing catapult applications strict. i.e launch.yml has to exist and $RUN_TYPE has to match the type of script that is called
- drop support for lambda/<region> runtype
- add support for glue runtype

Testing:
- successful glue test run https://app.circleci.com/pipelines/github/Clever/analytics-district-participation/567/workflows/e8af8d56-d09e-4741-8fc3-7f6aa04e71cf/jobs/2123 (failing due to a different bug, which I will fix in catapult in a bit)
- didn't do others as code change is straightforward