### PR TITLE
remove support for passing deployment strategy via dapple-deploy script

### DIFF
--- a/circleci/dapple-deploy
+++ b/circleci/dapple-deploy
@@ -4,7 +4,7 @@
 #
 # Usage:
 #
-#   dapple-deploy [DAPPLE_URL] [DAPPLE_USER] [DAPPLE_PASS] [APP_NAME] [[DEPLOY_ENV] [DEPLOY_STRATEGY]]
+#   dapple-deploy [DAPPLE_URL] [DAPPLE_USER] [DAPPLE_PASS] [APP_NAME]
 #
 # Required circleci provided environment variables:
 #
@@ -15,9 +15,9 @@
 
 set -e
 
-if [ $# -ne 4 ] && [ $# -ne 5 ] && [ $# -ne 6 ]; then
-    echo "Incorrect number of arguments given. Expected at least 4, received $#"
-    echo "Usage: dapple-deploy [DAPPLE_URL] [DAPPLE_USER] [DAPPLE_PASS] [APP_NAME] [[DEPLOY_ENV] [DEPLOY_STRATEGY]]"
+if [ $# -ne 4 ]; then
+    echo "Incorrect number of arguments given. Expected exactly 4, received $#"
+    echo "Usage: dapple-deploy [DAPPLE_URL] [DAPPLE_USER] [DAPPLE_PASS] [APP_NAME]"
     exit 1
 fi
 
@@ -26,10 +26,6 @@ DAPPLE_URL=$1
 DAPPLE_USER=$2
 DAPPLE_PASS=$3
 APP_NAME=$4
-# TODO: as part of INFRANG-4341 we would like to get rid of these 2 values. In the interim they will be ignored if the new launch config format is used.
-# deploy env and deploy strategy get default values, if not specified
-DEPLOY_ENV=${5:-clever-dev}
-DEPLOY_STRATEGY=${6:-confirm-then-deploy}
 
 # Set automatically by CircleCI
 : ${CIRCLE_PROJECT_REPONAME?"Missing required env var"}
@@ -40,24 +36,13 @@ USER=$CIRCLE_PROJECT_USERNAME
 BUILD_NUM=$CIRCLE_BUILD_NUM
 BRANCH=$CIRCLE_BRANCH
 
-# Safety Checks
-if [ "$DEPLOY_ENV" = "production" -a "$BRANCH" != "master" ]; then
-  echo "ERROR: Cannot publish into production from a non-master branch"
-  exit 1
-fi
-
-if [ "$DEPLOY_ENV" != "production" -a "$DEPLOY_ENV" != "clever-dev" -a "$DEPLOY_ENV" != "dev-infra" ]; then
-  echo "ERROR: Only 'production', 'clever-dev', and 'dev-infra' are supported deployment environments"
-  exit 1
-fi
-
 echo "Publishing to dapple..."
 SC=$(curl -u $DAPPLE_USER:$DAPPLE_PASS \
   -w "%{http_code}" \
   --output dapple.out \
   -H "Content-Type: application/json" \
   -X POST \
-  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\",\"environment\":\"$DEPLOY_ENV\",\"strategy\":\"$DEPLOY_STRATEGY\"}" \
+  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"appname\":\"$APP_NAME\"}" \
   $DAPPLE_URL)
 
 if [ "$SC" -eq 200 ]; then


### PR DESCRIPTION
Now that applications are migrated to use deploy config we can safely remove this code. We are also putting a hard check that only 4 arguments are passed to make sure there aren't any apps still trying to use the old thing