### PR TITLE
Make logic for detecting updated apps more specific

### DIFF
--- a/circleci/detect-updated-apps
+++ b/circleci/detect-updated-apps
@@ -36,13 +36,13 @@ do
         continue
     fi
     
-    # default to true, flips to false if it has a specific app's name in it's path
+    # default to true, flips to false if it the file belongs to a specific app
     is_global_file="true"
     
-    # if the file has any app's name in the path, mark that app as updated
+    # if the file in an app's cmd/app directory or if the file is the launch/app.yml file, update the app
     for app_name in ${all_app_names[@]+"${all_app_names[@]}"}
     do
-        if [[ $filename =~ $app_name ]]; then
+        if [[ $filename = cmd/$app_name/* ]] || [[ $filename = launch/$app_name.yml ]]; then
             updated_apps+=("$app_name")
             is_global_file="false"
             break


### PR DESCRIPTION
The great John Huang of IDM wanted to create an app called `idm-apply-changes-docker` when there is an already a lambda version called `idm-apply-changes`. Since the `detect-updated-apps` script only did simple substring matching, anytime the former app was updated, only the latter was being detected. This PR makes the matching more specific, looking to see if the file matches the `cmd/app` directory prefix or if it is the launch file

Screenshot shows that when the two files listed under the diff were updated, then detect-updated-apps correctly lists the two associated apps.

![Screen Shot 2022-07-08 at 4 43 27 PM](https://user-images.githubusercontent.com/26425483/178082548-8dfc0447-2ba5-4127-9ffa-62c9db884976.png)
.