### PR TITLE
Use yq to get run type

### DIFF
--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -15,6 +15,9 @@
 
 set -e
 
+DIR=$(dirname "$0")
+. $DIR/utils
+
 # User supplied args
 CATAPULT_URL=$1
 if [[ -z $CATAPULT_URL ]]; then echo "Missing arg1 CATAPULT_URL" && exit 1; fi
@@ -40,7 +43,9 @@ REPO=$CIRCLE_PROJECT_REPONAME
 SHORT_SHA=${CIRCLE_SHA1:0:7}
 FULL_SHA=${CIRCLE_SHA1}
 
-RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+install_yq
+
+RUN_TYPE=$(yq e '.run.type // "docker"' "launch/${APP_NAME}.yml")
 
 CIRCLE_CI_INTEGRATIONS_URL=$(dirname $CATAPULT_URL)
 

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -38,7 +38,9 @@ BRANCH=$CIRCLE_BRANCH
 
 install_awscli
 
-RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+install_yq
+
+RUN_TYPE=$(yq e '.run.type' "launch/${APP_NAME}.yml")
 if [[ $RUN_TYPE != "lambda" ]]; then
     echo "Can only publish applications with run type 'lambda' using this script; got ${RUN_TYPE}"
     exit 1

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -38,7 +38,9 @@ BRANCH=$CIRCLE_BRANCH
 
 install_awscli
 
-RUN_TYPE=$(grep type "launch/${APP_NAME}.yml" | cut -d' ' -f4)
+install_yq
+
+RUN_TYPE=$(yq e '.run.type' "launch/${APP_NAME}.yml")
 if [[ $RUN_TYPE != "glue" ]]; then
     echo "Can only publish applications with run type 'glue' using this script; got ${RUN_TYPE}"
     exit 1

--- a/circleci/utils
+++ b/circleci/utils
@@ -20,3 +20,17 @@ install_awscli(){
   sudo /tmp/aws/install
   echo "Completed AWS cli install"
 }
+
+install_yq(){
+  if type yq > /dev/null; then
+    echo "yq already installed"
+    return
+  fi
+
+  echo "Installing yq..."
+  mkdir -p "/tmp/bin"
+  wget -O "/tmp/bin/yq" "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64"
+  chmod +x "/tmp/bin/yq"
+  export PATH="/tmp/bin:$PATH"
+  echo "Completed yq install"
+}


### PR DESCRIPTION
Leftover of https://clever.atlassian.net/browse/INFRANG-4774

Getting the run type of a launch yml using `grep | cut` is pretty janky as seen [here](https://app.circleci.com/pipelines/github/Clever/hall-monitor/2042/workflows/a6a6c259-8560-4c4f-a2e7-70174f0a19c0/jobs/5738). Switching to yq will be more reliable. yq seems to be installed by default on all of the runners so unsure if the install script actually works.