### PR TITLE
added tool for tagging go sub-modules

### DIFF
--- a/circleci/github-release
+++ b/circleci/github-release
@@ -76,7 +76,7 @@ while [ $SECONDS -lt $end ]; do
     break
 done
 
-if [ release_created = "false" ]; then
+if [ $release_created == "false" ]; then
   echo "error: $SECONDS seconds have passed since we submitted request to create release but it is not yet created"
   exit 1
 fi

--- a/circleci/submodule-github-release
+++ b/circleci/submodule-github-release
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-# Publishes content from [MODULE_PATH] as a Github Release.
+# Publishes content from [MODULE_PATH] as a Github Release. (Modified from github-release)
 # Repo must have a VERSION file in its base directory.
+#
+# Expected VERSION format: 
+# semver on first line, then a blank line, then release notes. 
 #
 # Usage:
 #
+# MODULE_PATH here is the relative path to the submodule. 
 #   github-release [--pre-release] <GITHUB_TOKEN> [MODULE_PATH] 
 
 set -e
@@ -51,10 +55,12 @@ chmod +x $GITHUB_RELEASE
 echo "Publishing github-release"
 TAG="$(head -n 1 VERSION)"
 if [[ ${TAG:0:1} != "v" ]]; then TAG=v$TAG; fi
+
+# Prepending module path to version for tag. 
 if  [[ $MODULE_PATH != "/" ]]; then TAG="$MODULE_PATH$TAG"; fi 
+
 DESCRIPTION=$(tail -n +2 VERSION)
-echo "$MODULE_PATH"
-echo "$TAG"
+echo "Creating tag $TAG"
 # create a release and wait at most 60 seconds for it to be created
 export GITHUB_TOKEN=$GITHUB_TOKEN
 result=$($GITHUB_RELEASE release -u $USER -r $REPO -t $TAG -n "$TAG" -d "$DESCRIPTION" $PRE_RELEASE 2>&1 || true)
@@ -83,7 +89,7 @@ while [ $SECONDS -lt $end ]; do
     break
 done
 
-if [ release_created = "false" ]; then
+if [ $release_created == "false" ]; then
   echo "error: $SECONDS seconds have passed since we submitted request to create release but it is not yet created"
   exit 1
 fi

--- a/circleci/submodule-github-release
+++ b/circleci/submodule-github-release
@@ -1,22 +1,27 @@
 #!/bin/bash
 
-# Publishes content from [ARTIFACTS_DIR] as a Github Release.
+# Publishes content from [MODULE_PATH] as a Github Release.
 # Repo must have a VERSION file in its base directory.
 #
 # Usage:
 #
-#   github-release [--pre-release] <GITHUB_TOKEN> [ARTIFACTS_DIR] 
+#   github-release [--pre-release] <GITHUB_TOKEN> [MODULE_PATH] 
 
 set -e
 
 if [[ $1 == "--pre-release" ]]; then
   PRE_RELEASE="--pre-release"
   GITHUB_TOKEN=$2
-  ARTIFACTS_DIR=$3
+  MODULE_PATH=$3
 else
   PRE_RELEASE=""
   GITHUB_TOKEN=$1
-  ARTIFACTS_DIR=$2
+  MODULE_PATH=$2
+fi
+
+if [[ $MODULE_PATH != */ ]]
+then 
+  MODULE_PATH="$MODULE_PATH/"
 fi
 
 # User supplied args
@@ -44,10 +49,12 @@ fi
 chmod +x $GITHUB_RELEASE
 
 echo "Publishing github-release"
-TAG=$(head -n 1 VERSION)
+TAG="$(head -n 1 VERSION)"
 if [[ ${TAG:0:1} != "v" ]]; then TAG=v$TAG; fi
+if  [[ $MODULE_PATH != "/" ]]; then TAG="$MODULE_PATH$TAG"; fi 
 DESCRIPTION=$(tail -n +2 VERSION)
-
+echo "$MODULE_PATH"
+echo "$TAG"
 # create a release and wait at most 60 seconds for it to be created
 export GITHUB_TOKEN=$GITHUB_TOKEN
 result=$($GITHUB_RELEASE release -u $USER -r $REPO -t $TAG -n "$TAG" -d "$DESCRIPTION" $PRE_RELEASE 2>&1 || true)
@@ -79,24 +86,4 @@ done
 if [ release_created = "false" ]; then
   echo "error: $SECONDS seconds have passed since we submitted request to create release but it is not yet created"
   exit 1
-fi
-
-if [[ -z $ARTIFACTS_DIR ]]; then
-  echo "Skipping publishing artifacts. No ARTIFACTS_DIR set";
-else
-  for f in $ARTIFACTS_DIR; do
-      # treat directories and files differently
-      if [ -d $f ]; then
-          for ff in $(ls $f); do
-              echo -e "uploading $ff"
-              $GITHUB_RELEASE upload -u $USER -r $REPO -t $TAG -n $ff -f $f/$ff
-          done
-      elif [ -f $f ]; then
-          echo -e "uploading $f"
-          $GITHUB_RELEASE upload -u $USER -r $REPO -t $TAG -n $f -f $f
-      else
-          echo -e "$f is not a file or directory"
-          exit 1
-      fi
-  done
 fi


### PR DESCRIPTION
[INFRANG-5004](https://clever.atlassian.net/browse/INFRANG-5004)

A step along the way for this. 

We have decided that client and model versions should match the overall repo version, so this just tags each client and model separately. 

It's a slight modification of github-release that allows for specifying a sub directory as a module path. 

Used in circle ci config like:

`- run: if [ "${CIRCLE_BRANCH}" == "master" ]; then ~/ci-scripts/circleci/submodule-github-release $GITHUB_RELEASE_TOKEN gen-go/client`