### PR TITLE
Fix quotes.

### DIFF
--- a/circleci/output-force-deploy
+++ b/circleci/output-force-deploy
@@ -14,7 +14,7 @@ echo "2) Run the following command, replacing CIRCLE_API_TOKEN with the token fr
 echo "curl -u CIRCLE_API_TOKEN: \\
 -X POST \\
 --header \"Content-Type: application/json\" -d '{
-  \"branch\": "master",
+  \"branch\": \"master\",
   \"parameters\": {
     \"force_deploy\": true
     }


### PR DESCRIPTION
Quick fix: we want the output to be `"master"` which means we need to escape these double quotes; at present it outputs `"branch": master,` which is not valid JSON.