### PR TITLE
For now, don't fail the breakdown script when we cant post so it doesn't block CI

### DIFF
--- a/circleci/breakdown-sync
+++ b/circleci/breakdown-sync
@@ -73,5 +73,5 @@ if [ "$SC" -eq 200 ]; then
   exit 0
 else
   echo "Failed to publish to breakdown"
-  exit 1
+  exit 0
 fi


### PR DESCRIPTION
context: https://clever.slack.com/archives/C08G6CNMN/p1680728718765549