### PR TITLE
Update docker-publish to work with OIDC based aws authentication

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -42,7 +42,7 @@ image_exists() {
 }
 
 check_ecr_vars() {
-  # ECR required env vars. If CIRCLE_OIDC_TOKEN_V2 is defined via context, then use it to login to aws. 
+  # ECR required env vars. If OIDC_ECR_UPLOAD_ROLE is defined via context, then use it to login to aws. 
   if [[ -z $OIDC_ECR_UPLOAD_ROLE ]]; then
     if [[ -z $ECR_ACCOUNT_ID ]]; then echo "Missing var for ECR: ECR_ACCOUNT_ID" && exit 1; fi
     if [[ -z $ECR_PUSH_SECRET ]]; then echo "Missing var for ECR: ECR_PUSH_SECRET" && exit 1; fi
@@ -116,7 +116,7 @@ else
 fi
 
 # ECR login.
-if [[ -z $CIRCLE_OIDC_TOKEN_V2 ]]; then
+if [[ -z $OIDC_ECR_UPLOAD_ROLE ]]; then
   echo "Logging into ECR using static credentials..."
   ecr_login $ECR_REGION_US_WEST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
   ecr_login $ECR_REGION_US_WEST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -7,7 +7,7 @@
 #
 #   docker-publish 
 #   optional flag "-r private-repos" enables Docker Build Kit to allow ssh socket mounting to pull private modules/repos
-
+#   optional flag "-p profile" uses `profile` to authenticate into AWS without using the hardcoded env vars ECR_ACCOUNT_ID and ECR_PUSH_SECRET
 
 set -e
 
@@ -25,9 +25,10 @@ else
 fi
 
 readopt='none'
-while getopts 'r:' flag; do
+while getopts ':r:p:' flag; do
     case "${flag}" in
         r) readopt=${OPTARG};;
+        p) profile=${OPTARG};;
     esac
 done
 
@@ -43,14 +44,24 @@ image_exists() {
 
 check_ecr_vars() {
   # ECR required env vars
-  if [[ -z $ECR_ACCOUNT_ID ]]; then echo "Missing var for ECR: ECR_ACCOUNT_ID" && exit 1; fi
-  if [[ -z $ECR_PUSH_SECRET ]]; then echo "Missing var for ECR: ECR_PUSH_SECRET" && exit 1; fi
+  if [[ -z $profile ]]; then
+    if [[ -z $ECR_ACCOUNT_ID ]]; then echo "Missing var for ECR: ECR_ACCOUNT_ID" && exit 1; fi
+    if [[ -z $ECR_PUSH_SECRET ]]; then echo "Missing var for ECR: ECR_PUSH_SECRET" && exit 1; fi
+  else
+    echo "Using AWS profile '${profile}' to login to aws ecr"
+  fi
 }
 
 ecr_login(){
   REGION=$1
   ECR_REPO=$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
   AWS_ACCESS_KEY_ID=$2 AWS_SECRET_ACCESS_KEY=$3 aws ecr --region $REGION get-login-password | docker login --username AWS --password-stdin $ECR_REPO
+}
+
+ecr_login_with_profile(){
+  REGION=$1
+  ECR_REPO=$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+  aws ecr --region $REGION get-login-password --profile $2 | docker login --username AWS --password-stdin $ECR_REPO
 }
 
 push_ecr_image(){
@@ -102,10 +113,17 @@ fi
 
 # ECR login.
 echo "Logging into ECR..."
-ecr_login $ECR_REGION_US_WEST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
-ecr_login $ECR_REGION_US_WEST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET
-ecr_login $ECR_REGION_US_EAST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
-ecr_login $ECR_REGION_US_EAST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET
+if [[ -z $profile ]]; then
+  ecr_login $ECR_REGION_US_WEST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
+  ecr_login $ECR_REGION_US_WEST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET
+  ecr_login $ECR_REGION_US_EAST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
+  ecr_login $ECR_REGION_US_EAST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET
+else
+  ecr_login_with_profile $ECR_REGION_US_WEST_1 $profile
+  ecr_login_with_profile $ECR_REGION_US_WEST_2 $profile
+  ecr_login_with_profile $ECR_REGION_US_EAST_1 $profile
+  ecr_login_with_profile $ECR_REGION_US_EAST_2 $profile
+fi
 
 echo "Pushing to ECR..."
 push_ecr_image $ECR_REGION_US_WEST_1

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -8,6 +8,7 @@
 #   docker-publish 
 #   optional flag "-r private-repos" enables Docker Build Kit to allow ssh socket mounting to pull private modules/repos
 
+
 set -e
 
 DIR=$(dirname "$0")
@@ -24,7 +25,7 @@ else
 fi
 
 readopt='none'
-while getopts ':r' flag; do
+while getopts 'r:' flag; do
     case "${flag}" in
         r) readopt=${OPTARG};;
     esac

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -51,10 +51,6 @@ check_ecr_vars() {
       echo "Role name is required when using CIRCLE_OIDC_TOKEN_V2 to login to aws."
       exit 1
     fi
-    if [ -z "${CIRCLE_OIDC_TOKEN_V2}" ]; then
-      echo "OIDC Token cannot be found. A CircleCI context must be specified."
-      exit 1
-    fi
     echo "Using AWS role '${OIDC_ECR_UPLOAD_ROLE}' to login to aws ecr"
   fi
 }

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -7,7 +7,6 @@
 #
 #   docker-publish 
 #   optional flag "-r private-repos" enables Docker Build Kit to allow ssh socket mounting to pull private modules/repos
-#   optional flag "-p profile" uses `profile` to authenticate into AWS without using the hardcoded env vars ECR_ACCOUNT_ID and ECR_PUSH_SECRET
 
 set -e
 
@@ -25,10 +24,9 @@ else
 fi
 
 readopt='none'
-while getopts ':r:p:' flag; do
+while getopts ':r' flag; do
     case "${flag}" in
         r) readopt=${OPTARG};;
-        p) profile=${OPTARG};;
     esac
 done
 
@@ -43,12 +41,20 @@ image_exists() {
 }
 
 check_ecr_vars() {
-  # ECR required env vars
-  if [[ -z $profile ]]; then
+  # ECR required env vars. If CIRCLE_OIDC_TOKEN_V2 is defined via context, then use it to login to aws. 
+  if [[ -z $CIRCLE_OIDC_TOKEN_V2 ]]; then
     if [[ -z $ECR_ACCOUNT_ID ]]; then echo "Missing var for ECR: ECR_ACCOUNT_ID" && exit 1; fi
     if [[ -z $ECR_PUSH_SECRET ]]; then echo "Missing var for ECR: ECR_PUSH_SECRET" && exit 1; fi
   else
-    echo "Using AWS profile '${profile}' to login to aws ecr"
+    if [ -z "${OIDC_ECR_UPLOAD_ROLE}" ]; then
+      echo "Role name is required when using CIRCLE_OIDC_TOKEN_V2 to login to aws."
+      exit 1
+    fi
+    if [ -z "${CIRCLE_OIDC_TOKEN_V2}" ]; then
+      echo "OIDC Token cannot be found. A CircleCI context must be specified."
+      exit 1
+    fi
+    echo "Using AWS role '${OIDC_ECR_UPLOAD_ROLE}' to login to aws ecr"
   fi
 }
 
@@ -61,7 +67,7 @@ ecr_login(){
 ecr_login_with_profile(){
   REGION=$1
   ECR_REPO=$ECR_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
-  aws ecr --region $REGION get-login-password --profile $2 | docker login --username AWS --password-stdin $ECR_REPO
+  aws ecr --region $REGION get-login-password --profile $AWS_ECR_PROFILE | docker login --username AWS --password-stdin $ECR_REPO
 }
 
 push_ecr_image(){
@@ -87,6 +93,7 @@ ECR_REGION_US_WEST_1=us-west-1
 ECR_REGION_US_WEST_2=us-west-2
 ECR_REGION_US_EAST_1=us-east-1
 ECR_REGION_US_EAST_2=us-east-2
+AWS_ECR_PROFILE=oidc-ecr-profile
 
 echo "Docker version..."
 docker version
@@ -112,17 +119,19 @@ else
 fi
 
 # ECR login.
-echo "Logging into ECR..."
-if [[ -z $profile ]]; then
+if [[ -z $CIRCLE_OIDC_TOKEN_V2 ]]; then
+  echo "Logging into ECR using static credentials..."
   ecr_login $ECR_REGION_US_WEST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
   ecr_login $ECR_REGION_US_WEST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET
   ecr_login $ECR_REGION_US_EAST_1 $ECR_PUSH_ID $ECR_PUSH_SECRET
   ecr_login $ECR_REGION_US_EAST_2 $ECR_PUSH_ID $ECR_PUSH_SECRET
 else
-  ecr_login_with_profile $ECR_REGION_US_WEST_1 $profile
-  ecr_login_with_profile $ECR_REGION_US_WEST_2 $profile
-  ecr_login_with_profile $ECR_REGION_US_EAST_1 $profile
-  ecr_login_with_profile $ECR_REGION_US_EAST_2 $profile
+  echo "Logging into ECR using role credentials..."
+  assume_role_with_web_identity $OIDC_ECR_UPLOAD_ROLE $AWS_ECR_PROFILE 
+  ecr_login_with_profile $ECR_REGION_US_WEST_1
+  ecr_login_with_profile $ECR_REGION_US_WEST_2
+  ecr_login_with_profile $ECR_REGION_US_EAST_1
+  ecr_login_with_profile $ECR_REGION_US_EAST_2
 fi
 
 echo "Pushing to ECR..."

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -43,15 +43,15 @@ image_exists() {
 
 check_ecr_vars() {
   # ECR required env vars. If CIRCLE_OIDC_TOKEN_V2 is defined via context, then use it to login to aws. 
-  if [[ -z $CIRCLE_OIDC_TOKEN_V2 ]]; then
+  if [[ -z $OIDC_ECR_UPLOAD_ROLE ]]; then
     if [[ -z $ECR_ACCOUNT_ID ]]; then echo "Missing var for ECR: ECR_ACCOUNT_ID" && exit 1; fi
     if [[ -z $ECR_PUSH_SECRET ]]; then echo "Missing var for ECR: ECR_PUSH_SECRET" && exit 1; fi
   else
-    if [ -z "${OIDC_ECR_UPLOAD_ROLE}" ]; then
-      echo "Role name is required when using CIRCLE_OIDC_TOKEN_V2 to login to aws."
+    if [ -z "${CIRCLE_OIDC_TOKEN_V2}" ]; then
+      echo "OIDC Token cannot be found. A CircleCI context must be specified."
       exit 1
     fi
-    echo "Using AWS role '${OIDC_ECR_UPLOAD_ROLE}' to login to aws ecr"
+    echo "Using AWS role defined in \$OIDC_ECR_UPLOAD_ROLE to login to aws ecr"
   fi
 }
 

--- a/circleci/utils
+++ b/circleci/utils
@@ -22,13 +22,12 @@ install_awscli(){
 }
 
 assume_role_with_web_identity() {
-  echo "Setting aws profile to $2"
   aws configure set profile $2
-  echo "Authenticating via role $1..."
   aws sts assume-role-with-web-identity \
     --role-arn "$1" \
     --role-session-name "oidc-ecr-role-session" \
     --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
+    --profile $2 \
     --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
     --output text > /tmp/cred.txt
   read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN < /tmp/cred.txt 

--- a/circleci/utils
+++ b/circleci/utils
@@ -23,14 +23,15 @@ install_awscli(){
 
 assume_role_with_web_identity() {
   aws configure set profile $2
-  aws sts assume-role-with-web-identity \
+  read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN << EOF
+  $(aws sts assume-role-with-web-identity \
     --role-arn "$1" \
     --role-session-name "oidc-ecr-role-session" \
     --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
     --profile $2 \
     --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-    --output text > /tmp/cred.txt
-  read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN < /tmp/cred.txt 
+    --output text)
+EOF
   
   if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
     echo "Failed to assume role";

--- a/circleci/utils
+++ b/circleci/utils
@@ -21,6 +21,29 @@ install_awscli(){
   echo "Completed AWS cli install"
 }
 
+assume_role_with_web_identity() {
+  echo "Setting aws profile to $2"
+  aws configure set profile $2
+  echo "Authenticating via role $1..."
+  aws sts assume-role-with-web-identity \
+    --role-arn "$1" \
+    --role-session-name "oidc-ecr-role-session" \
+    --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
+    --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+    --output text > /tmp/cred.txt
+  read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN < /tmp/cred.txt 
+  
+  if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
+    echo "Failed to assume role";
+    exit 1
+  else
+    aws configure set aws_access_key_id ${AWS_ACCESS_KEY_ID} --profile $2
+    aws configure set aws_secret_access_key ${AWS_SECRET_ACCESS_KEY} --profile $2
+    aws configure set aws_session_token ${AWS_SESSION_TOKEN} --profile $2
+    echo "Assume role with web identity succeeded."
+  fi
+}
+
 install_yq(){
   if type yq > /dev/null; then
     echo "yq already installed"

--- a/circleci/utils
+++ b/circleci/utils
@@ -28,7 +28,6 @@ assume_role_with_web_identity() {
     --role-arn "$1" \
     --role-session-name "oidc-ecr-role-session" \
     --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
-    --profile $2 \
     --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
     --output text)
 EOF


### PR DESCRIPTION
https://clever.atlassian.net/browse/SECNG-1770

This enables ability to use the following as demonstrated in https://github.com/Clever/test-frontend-app/pull/66
When `CIRCLE_OIDC_TOKEN_V2` and `OIDC_ECR_UPLOAD_ROLE` env vars are defined via `aws` context of CIrcleCI (https://app.circleci.com/settings/organization/github/Clever/contexts/30b0642a-9620-4546-a1b2-a37382ea331c?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2FClever%2Ftest-frontend-app%2F191%2Fworkflows%2Fb0c87d53-2f6b-4932-a142-653ca91c4b78%2Fjobs%2F704), this `docker-publish` script leverages them to issue `assume_role_with_web_identity` aws call and get role-based temp credentials.

