### PR TITLE
Update aws s3 operations with profile

### DIFF
--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -44,7 +44,7 @@ install_awscli
 AWS_LAMBDA_PROFILE=oidc-lambda-profile
 if [[ -v OIDC_LAMBDA_ROLE ]]; then
   echo "Logging into AWS using role credentials...."
-  assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_LAMBDA_PROFILE 
+  assume_role_with_web_identity $OIDC_LAMBDA_ROLE $AWS_LAMBDA_PROFILE 
 fi
 
 install_yq

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -29,14 +29,23 @@ BUILD_NUM=$CIRCLE_BUILD_NUM
 BRANCH=$CIRCLE_BRANCH
 
 # Set by init service
-: ${LAMBDA_AWS_ACCESS_KEY_ID?"Missing required env var"}
-: ${LAMBDA_AWS_SECRET_ACCESS_KEY?"Missing required env var"}
-: ${LAMBDA_AWS_BUCKET?"Missing required env var"}
 : ${CATAPULT_URL?"Missing required env var"}
 : ${CATAPULT_USER?"Missing required env var"}
 : ${CATAPULT_PASS?"Missing required env var"}
+if [[ -z $OIDC_LAMBDA_ROLE ]]; then
+    : ${LAMBDA_AWS_ACCESS_KEY_ID?"Missing required env var"}
+    : ${LAMBDA_AWS_SECRET_ACCESS_KEY?"Missing required env var"}
+    : ${LAMBDA_AWS_BUCKET?"Missing required env var"}
+fi
 
 install_awscli
+
+# aws login.
+AWS_LAMBDA_PROFILE=oidc-lambda-profile
+if [[ -v $OIDC_LAMBDA_ROLE ]]; then
+  echo "Logging into AWS using role credentials...."
+  assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_LAMBDA_PROFILE 
+fi
 
 install_yq
 
@@ -61,22 +70,31 @@ fi
 LAMBDA_AWS_S3_KEY=${APP_NAME}/${SHORT_SHA}/${APP_NAME}.zip
 
 # upload to s3
-echo "Uploading to S3..."
 for AWS_REGION in ${AWS_REGIONS}; do
     # region doesn't really matter for an S3 upload, since the bucket region is fixed
-    AWS_REGION=$AWS_REGION \
-              AWS_ACCESS_KEY_ID=$LAMBDA_AWS_ACCESS_KEY_ID \
-              AWS_SECRET_ACCESS_KEY=$LAMBDA_AWS_SECRET_ACCESS_KEY \
-              aws s3 cp bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
+    AWS_REGION=$AWS_REGION
+    if [[ -v $OIDC_LAMBDA_ROLE ]]; then
+        echo "Uploading to S3 using profile `$AWS_LAMBDA_PROFILE`"
+        aws s3 --profile $AWS_LAMBDA_PROFILE cp bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
+    else
+        echo "Uploading to S3 using static credential"
+        AWS_ACCESS_KEY_ID=$LAMBDA_AWS_ACCESS_KEY_ID \
+        AWS_SECRET_ACCESS_KEY=$LAMBDA_AWS_SECRET_ACCESS_KEY \
+        aws s3 cp bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
+    fi
 
     if [ -e swagger.yml ]; then
-        echo "Uploading swagger.yml"
         # api gateway fails to parse on x-nullable
         sed '/x-nullable/d' ./swagger.yml > ./swagger.lambda.yml
-        AWS_REGION=$AWS_REGION \
-                  AWS_ACCESS_KEY_ID=$LAMBDA_AWS_ACCESS_KEY_ID \
-                  AWS_SECRET_ACCESS_KEY=$LAMBDA_AWS_SECRET_ACCESS_KEY \
-                  aws s3 cp swagger.lambda.yml s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${APP_NAME}/${SHORT_SHA}/swagger.lambda.yml
+        if [[ -v $OIDC_LAMBDA_ROLE ]]; then
+            echo "Uploading swagger.yml using profile `$AWS_LAMBDA_PROFILE`"
+            aws s3 --profile $AWS_LAMBDA_PROFILE cp swagger.lambda.yml s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${APP_NAME}/${SHORT_SHA}/swagger.lambda.yml
+        else
+            echo "Uploading swagger.yml using static credential"
+            AWS_ACCESS_KEY_ID=$LAMBDA_AWS_ACCESS_KEY_ID \
+            AWS_SECRET_ACCESS_KEY=$LAMBDA_AWS_SECRET_ACCESS_KEY \
+            aws s3 cp swagger.lambda.yml s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${APP_NAME}/${SHORT_SHA}/swagger.lambda.yml
+        fi
     fi
 done;
 

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -74,8 +74,8 @@ for AWS_REGION in ${AWS_REGIONS}; do
     # region doesn't really matter for an S3 upload, since the bucket region is fixed
     AWS_REGION=$AWS_REGION
     if [[ -v OIDC_LAMBDA_ROLE ]]; then
-        echo "Uploading to S3 using profile `$AWS_LAMBDA_PROFILE`"
-        aws s3 --profile $AWS_LAMBDA_PROFILE cp bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
+        echo "Uploading to S3 using profile ${AWS_LAMBDA_PROFILE}"
+        aws s3 cp --profile $AWS_LAMBDA_PROFILE  bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
     else
         echo "Uploading to S3 using static credential"
         AWS_ACCESS_KEY_ID=$LAMBDA_AWS_ACCESS_KEY_ID \

--- a/circleci/catapult-publish-lambda
+++ b/circleci/catapult-publish-lambda
@@ -42,7 +42,7 @@ install_awscli
 
 # aws login.
 AWS_LAMBDA_PROFILE=oidc-lambda-profile
-if [[ -v $OIDC_LAMBDA_ROLE ]]; then
+if [[ -v OIDC_LAMBDA_ROLE ]]; then
   echo "Logging into AWS using role credentials...."
   assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_LAMBDA_PROFILE 
 fi
@@ -73,7 +73,7 @@ LAMBDA_AWS_S3_KEY=${APP_NAME}/${SHORT_SHA}/${APP_NAME}.zip
 for AWS_REGION in ${AWS_REGIONS}; do
     # region doesn't really matter for an S3 upload, since the bucket region is fixed
     AWS_REGION=$AWS_REGION
-    if [[ -v $OIDC_LAMBDA_ROLE ]]; then
+    if [[ -v OIDC_LAMBDA_ROLE ]]; then
         echo "Uploading to S3 using profile `$AWS_LAMBDA_PROFILE`"
         aws s3 --profile $AWS_LAMBDA_PROFILE cp bin/${APP_NAME}.zip s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${LAMBDA_AWS_S3_KEY}
     else
@@ -86,7 +86,7 @@ for AWS_REGION in ${AWS_REGIONS}; do
     if [ -e swagger.yml ]; then
         # api gateway fails to parse on x-nullable
         sed '/x-nullable/d' ./swagger.yml > ./swagger.lambda.yml
-        if [[ -v $OIDC_LAMBDA_ROLE ]]; then
+        if [[ -v OIDC_LAMBDA_ROLE ]]; then
             echo "Uploading swagger.yml using profile `$AWS_LAMBDA_PROFILE`"
             aws s3 --profile $AWS_LAMBDA_PROFILE cp swagger.lambda.yml s3://${LAMBDA_AWS_BUCKET}-${AWS_REGION}/${APP_NAME}/${SHORT_SHA}/swagger.lambda.yml
         else

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -38,6 +38,13 @@ BRANCH=$CIRCLE_BRANCH
 
 install_awscli
 
+# aws login.
+AWS_GLUE_PROFILE=oidc-glue-profile
+if [[ -v $OIDC_GLUE_UPLOAD_ROLE ]]; then
+  echo "Logging into AWS using role credentials...."
+  assume_role_with_web_identity $OIDC_GLUE_UPLOAD_ROLE $AWS_GLUE_PROFILE 
+fi
+
 install_yq
 
 RUN_TYPE=$(yq e '.run.type' "launch/${APP_NAME}.yml")
@@ -57,11 +64,16 @@ CATAPULT_URL=$(echo "${CATAPULT_URL}" | sed 's/\/catapult/\/v2\/catapult/')
 GLUE_AWS_S3_KEY=${APP_NAME}/${SHORT_SHA}
 
 # upload to s3
-echo "Uploading to S3..."
-AWS_REGION=$AWS_REGION \
-          AWS_ACCESS_KEY_ID=$GLUE_AWS_ACCESS_KEY_ID \
-          AWS_SECRET_ACCESS_KEY=$GLUE_AWS_SECRET_ACCESS_KEY \
-          aws s3 cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
+AWS_REGION=$AWS_REGION
+if [[ -v $OIDC_GLUE_UPLOAD_ROLE ]]; then
+    echo "Uploading to S3 using profile `$AWS_GLUE_PROFILE`"
+    aws s3 --profile $AWS_GLUE_PROFILE cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
+else
+    echo "Uploading to S3 using static credential..."
+    AWS_ACCESS_KEY_ID=$GLUE_AWS_ACCESS_KEY_ID \
+    AWS_SECRET_ACCESS_KEY=$GLUE_AWS_SECRET_ACCESS_KEY \
+    aws s3 cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
+fi
 
 # publish the application to catapult
 echo "Publishing to catapult..."

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -66,8 +66,8 @@ GLUE_AWS_S3_KEY=${APP_NAME}/${SHORT_SHA}
 # upload to s3
 AWS_REGION=$AWS_REGION
 if [[ -v OIDC_GLUE_UPLOAD_ROLE ]]; then
-    echo "Uploading to S3 using profile `$AWS_GLUE_PROFILE`"
-    aws s3 --profile $AWS_GLUE_PROFILE cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
+    echo "Uploading to S3 using profile ${AWS_GLUE_PROFILE}"
+    aws s3 cp --profile $AWS_GLUE_PROFILE --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
 else
     echo "Uploading to S3 using static credential..."
     AWS_ACCESS_KEY_ID=$GLUE_AWS_ACCESS_KEY_ID \

--- a/circleci/catapult-publish-spark
+++ b/circleci/catapult-publish-spark
@@ -40,7 +40,7 @@ install_awscli
 
 # aws login.
 AWS_GLUE_PROFILE=oidc-glue-profile
-if [[ -v $OIDC_GLUE_UPLOAD_ROLE ]]; then
+if [[ -v OIDC_GLUE_UPLOAD_ROLE ]]; then
   echo "Logging into AWS using role credentials...."
   assume_role_with_web_identity $OIDC_GLUE_UPLOAD_ROLE $AWS_GLUE_PROFILE 
 fi
@@ -65,7 +65,7 @@ GLUE_AWS_S3_KEY=${APP_NAME}/${SHORT_SHA}
 
 # upload to s3
 AWS_REGION=$AWS_REGION
-if [[ -v $OIDC_GLUE_UPLOAD_ROLE ]]; then
+if [[ -v OIDC_GLUE_UPLOAD_ROLE ]]; then
     echo "Uploading to S3 using profile `$AWS_GLUE_PROFILE`"
     aws s3 --profile $AWS_GLUE_PROFILE cp --recursive bin/${APP_NAME} s3://${GLUE_AWS_BUCKET}-${AWS_REGION}/${GLUE_AWS_S3_KEY}
 else

--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -75,8 +75,8 @@ fi
 echo "  Source: $SOURCE_DIR_OR_FILE"
 echo "  Desination: $S3_BUCKET_URL"
 if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
-    echo "Uploading files to S3 using profile `$AWS_S3_PROFILE`" 
-    aws s3 --profile $AWS_S3_PROFILE cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
+    echo "Uploading files to S3 using profile $AWS_S3_PROFILE" 
+    aws s3 cp --profile $AWS_S3_PROFILE  $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
 else
     echo "Uploading files to S3 using static credentials" 
     aws s3 cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS

--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -67,14 +67,14 @@ fi
 install_awscli
 # aws login.
 AWS_S3_PROFILE=oidc-s3-profile
-if [[ -v $OIDC_S3_UPLOAD_ROLE ]]; then
+if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
   echo "Logging into AWS using role credentials...."
   assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_S3_PROFILE 
 fi
 
 echo "  Source: $SOURCE_DIR_OR_FILE"
 echo "  Desination: $S3_BUCKET_URL"
-if [[ -v $OIDC_S3_UPLOAD_ROLE ]]; then
+if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
     echo "Uploading files to S3 using profile `$AWS_S3_PROFILE`" 
     aws s3 --profile $AWS_S3_PROFILE cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
 else

--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -75,7 +75,7 @@ fi
 echo "  Source: $SOURCE_DIR_OR_FILE"
 echo "  Desination: $S3_BUCKET_URL"
 if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
-    echo "Uploading files to S3 using profile $AWS_S3_PROFILE" 
+    echo "Uploading files to S3 using profile ${AWS_S3_PROFILE}" 
     aws s3 cp --profile $AWS_S3_PROFILE  $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
 else
     echo "Uploading files to S3 using static credentials" 

--- a/circleci/s3-upload
+++ b/circleci/s3-upload
@@ -65,8 +65,19 @@ if [[ $CONTENT_ENCODING == "gzip" ]]; then
 fi
 
 install_awscli
+# aws login.
+AWS_S3_PROFILE=oidc-s3-profile
+if [[ -v $OIDC_S3_UPLOAD_ROLE ]]; then
+  echo "Logging into AWS using role credentials...."
+  assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_S3_PROFILE 
+fi
 
-echo "Uploading files to S3..."
 echo "  Source: $SOURCE_DIR_OR_FILE"
 echo "  Desination: $S3_BUCKET_URL"
-aws s3 cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
+if [[ -v $OIDC_S3_UPLOAD_ROLE ]]; then
+    echo "Uploading files to S3 using profile `$AWS_S3_PROFILE`" 
+    aws s3 --profile $AWS_S3_PROFILE cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
+else
+    echo "Uploading files to S3 using static credentials" 
+    aws s3 cp $DIR_OR_FILE_TO_UPLOAD $S3_BUCKET_URL --acl "private" --cache-control "max-age=31536000" $ADDITIONAL_S3_FLAGS
+fi


### PR DESCRIPTION
This updates AWS s3 operations to be using role-based credentials that is optionally defined within the CircleCI `context` for https://clever.atlassian.net/browse/SECNG-1831

## Testing for s3-upload
https://github.com/Clever/oauth/pull/2521/ where CircleCI context `aws-s3-upload` is used to pass the [CircleCIOidcS3Upload](https://us-east-1.console.aws.amazon.com/iamv2/home#/roles/details/CircleCIOidcS3Upload-c1f83400e3) role into the script. And the CI job successfully passes: https://app.circleci.com/pipelines/github/Clever/oauth/3502/workflows/b41b9d57-5fca-4d68-9584-9afa897d39f1/jobs/14230

## Testing for catapult-publish-lambda
https://github.com/Clever/security-alerts-consumer/pull/56 where CircleCI context `aws-lambda-private` is used to pass the [CircleCIOidcLambdaPrivate](https://us-east-1.console.aws.amazon.com/iamv2/home#/roles/details/CircleCIOidcLambdaPrivate-f435d1d679) role into the script. And the CI job successfully passes: https://app.circleci.com/pipelines/github/Clever/security-alerts-consumer/118/workflows/32dc7435-7313-42d0-81dd-3fd5417ba17e/jobs/535

## Testing for catapult-publish-spark
https://github.com/Clever/analytics-district-participation/pull/78/ where CircleCI context `aws-glue-upload` is used to pass the [CircleCIOidcGlueUpload](https://us-east-1.console.aws.amazon.com/iamv2/home#/roles/details/CircleCIOidcGlueUpload-8aa3ec726b) role into the script. And the CI job successfully passes: https://app.circleci.com/pipelines/github/Clever/analytics-district-participation/579/workflows/dea778da-9c17-490f-b622-43621de555bc/jobs/2197

