### PR TITLE
Download breakdowncli using github token

### DIFF
--- a/circleci/utils
+++ b/circleci/utils
@@ -65,7 +65,7 @@ install_breakdowncli(){
 
   echo "Installing breakdowncli..."
   mkdir -p "/tmp/bin"
-  wget -O "/tmp/bin/breakdowncli" "https://github.com/Clever/breakdown/releases/download/breakdowncli%2Fv0.1.3/breakdowncli-v0.1.3-linux-amd64"
+  wget -O "/tmp/bin/breakdowncli" --header="Authorization: Bearer $GITHUB_RELEASE_TOKEN" "https://github.com/Clever/breakdown/releases/download/breakdowncli%2Fv0.1.3/breakdowncli-v0.1.3-linux-amd64"
   chmod +x "/tmp/bin/breakdowncli"
   export PATH="/tmp/bin:$PATH"
   echo "Completed breakdowncli install"


### PR DESCRIPTION
Download breakdowncli using `$GITHUB_RELEASE_TOKEN` in anticipation of breakdown going private. Unsure if this token has enough permissions, I assume it does since it's able to create releases.