### PR TITLE
Download e2e test artifacts from s3

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -92,7 +92,7 @@ download_test_artifacts(){
   mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
   for workflowID in $(cat integration-tests.out | jq -r '.testWorkflowIds[]');
   do
-    S3_BUCKET_URL="s3://frontend-to-end-tester-files/${workflowID}/artifacts.zip"
+    S3_BUCKET_URL="s3://frontend-to-end-tester-files-dev/${workflowID}/artifacts.zip"
     DEST="${CIRCLE_ARTIFACTS}/${workflowID}"
     echo "  Source: $S3_BUCKET_URL"
     echo "  Desination: $DEST"

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -55,28 +55,28 @@ APPS=$(echo "${APP_NAMES}" |
     )
 
 echo "Submitting to integration-testing-service..."
-SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
-  -w "%{http_code}" \
-  --output integration-tests.out \
-  -H "Content-Type: application/json" \
-  -X POST \
-  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"apps\":${APPS},\"tests\":${TESTS_TO_RUN}}" \
-  $TESTING_SERVICE_URL)
+# SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
+#   -w "%{http_code}" \
+#   --output integration-tests.out \
+#   -H "Content-Type: application/json" \
+#   -X POST \
+#   -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"apps\":${APPS},\"tests\":${TESTS_TO_RUN}}" \
+#   $TESTING_SERVICE_URL)
 
-if [[ $SC -eq 200 ]]; then
-  echo "Successfully submitted to integration-testing-service"
-  JOB_ID=$(cat integration-tests.out | jq -r '.jobId')
-  rm -f integration-tests.out
-else
-  echo "Failed to submit tests to integration-testing-service"
-  echo "------------------------------------------------"
-  cat integration-tests.out
-  echo ""
-  echo "------------------------------------------------"
-  rm -f integration-tests.out
-  exit 1
-fi
-
+# if [[ $SC -eq 200 ]]; then
+#   echo "Successfully submitted to integration-testing-service"
+#   JOB_ID=$(cat integration-tests.out | jq -r '.jobId')
+#   rm -f integration-tests.out
+# else
+#   echo "Failed to submit tests to integration-testing-service"
+#   echo "------------------------------------------------"
+#   cat integration-tests.out
+#   echo ""
+#   echo "------------------------------------------------"
+#   rm -f integration-tests.out
+#   exit 1
+# fi
+JOB_ID="ba147bda-894a-4ad0-b2f1-9c53fc547cd7"
 echo "Job ID: $JOB_ID"
 
 install_awscli

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -55,28 +55,28 @@ APPS=$(echo "${APP_NAMES}" |
     )
 
 echo "Submitting to integration-testing-service..."
-# SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
-#   -w "%{http_code}" \
-#   --output integration-tests.out \
-#   -H "Content-Type: application/json" \
-#   -X POST \
-#   -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"apps\":${APPS},\"tests\":${TESTS_TO_RUN}}" \
-#   $TESTING_SERVICE_URL)
+SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
+  -w "%{http_code}" \
+  --output integration-tests.out \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "{\"username\":\"$USER\",\"reponame\":\"$REPO\",\"buildnum\":$BUILD_NUM,\"apps\":${APPS},\"tests\":${TESTS_TO_RUN}}" \
+  $TESTING_SERVICE_URL)
 
-# if [[ $SC -eq 200 ]]; then
-#   echo "Successfully submitted to integration-testing-service"
-#   JOB_ID=$(cat integration-tests.out | jq -r '.jobId')
-#   rm -f integration-tests.out
-# else
-#   echo "Failed to submit tests to integration-testing-service"
-#   echo "------------------------------------------------"
-#   cat integration-tests.out
-#   echo ""
-#   echo "------------------------------------------------"
-#   rm -f integration-tests.out
-#   exit 1
-# fi
-JOB_ID="ba147bda-894a-4ad0-b2f1-9c53fc547cd7"
+if [[ $SC -eq 200 ]]; then
+  echo "Successfully submitted to integration-testing-service"
+  JOB_ID=$(cat integration-tests.out | jq -r '.jobId')
+  rm -f integration-tests.out
+else
+  echo "Failed to submit tests to integration-testing-service"
+  echo "------------------------------------------------"
+  cat integration-tests.out
+  echo ""
+  echo "------------------------------------------------"
+  rm -f integration-tests.out
+  exit 1
+fi
+
 echo "Job ID: $JOB_ID"
 
 install_awscli

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -90,18 +90,21 @@ fi
 download_test_artifacts(){
   echo "Downloading test artifacts"
   mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-  TEST_WORKFLOW_ID=$(cat integration-tests.out | jq '.testWorkflowID')
-  S3_BUCKET_URL="s3://frontend-to-end-tester-files/${TEST_WORKFLOW_ID}/artifacts.zip"
-  echo "  Source: $S3_BUCKET_URL"
-  echo "  Desination: $CIRCLE_ARTIFACTS"
-  if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
-      echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
-      aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $CIRCLE_ARTIFACTS
-  else
-      echo "Downloading files from S3 using static credentials" 
-      aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
-  fi
-  unzip $CIRCLE_ARTIFACTS/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS
+  for workflowID in $(cat integration-tests.out | jq -r '.testWorkflowIds[]');
+  do
+    S3_BUCKET_URL="s3://frontend-to-end-tester-files/${workflowID}/artifacts.zip"
+    DEST="${CIRCLE_ARTIFACTS}/${workflowID}"
+    echo "  Source: $S3_BUCKET_URL"
+    echo "  Desination: $DEST"
+    if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
+        echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
+        aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $DEST
+    else
+        echo "Downloading files from S3 using static credentials" 
+        aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+    fi
+    unzip $DEST/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS/${workflowID}
+  done
 }
 
 echo "Waiting 1 minute before polling"

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -76,7 +76,7 @@ echo "Submitting to integration-testing-service..."
 #   rm -f integration-tests.out
 #   exit 1
 # fi
-JOB_ID="c7f67fa9-813f-4850-b28a-0c6c8c409ece"
+JOB_ID="ba147bda-894a-4ad0-b2f1-9c53fc547cd7"
 echo "Job ID: $JOB_ID"
 
 install_awscli
@@ -108,7 +108,7 @@ download_test_artifacts(){
 }
 
 echo "Waiting 1 minute before polling"
-# sleep 1m
+sleep 1m
 
 echo "Polling every 30 seconds for test completion"
 
@@ -118,7 +118,7 @@ echo "Polling every 30 seconds for test completion"
 MAX_POLLS=90
 for ((i=1;i<=MAX_POLLS;i++))
 do
-  # sleep 30s
+  sleep 30s
   SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
     -w "%{http_code}" \
     --output integration-tests.out \

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -93,7 +93,7 @@ download_test_artifacts(){
   for workflowID in $(cat integration-tests.out | jq -r '.testWorkflowIds[]');
   do
     S3_BUCKET_URL="s3://frontend-to-end-tester-files-dev/${workflowID}/artifacts.zip"
-    DEST="${CIRCLE_ARTIFACTS}/${workflowID}"
+    DEST="${CIRCLE_ARTIFACTS}/${workflowID}/artifacts.zip"
     echo "  Source: $S3_BUCKET_URL"
     echo "  Desination: $DEST"
     if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
@@ -103,7 +103,7 @@ download_test_artifacts(){
         echo "Downloading files from S3 using static credentials" 
         aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
     fi
-    unzip $DEST/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS/${workflowID}
+    unzip $DEST test-results.xml -d $CIRCLE_TEST_REPORTS/${workflowID}
   done
 }
 

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -129,7 +129,9 @@ do
   if [[ $SC -eq 200 ]]; then
     echo "------------------------------------------------"
     STATUS=$(cat integration-tests.out | jq '.status')
+    OUT=$(cat integration-tests.out | jq)
     echo "Tests status: $STATUS"
+    echo "Out: $OUT"
     if [[ $STATUS == '"succeeded"' ]]; then
       download_test_artifacts
       rm -f integration-tests.out

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -15,6 +15,9 @@
 
 set -e
 
+DIR=$(dirname "$0")
+. $DIR/utils
+
 if [ $# -ne 4 ] && [ $# -ne 5 ] && [ $# -ne 6 ]; then
     echo "Incorrect number of arguments given. Expected at least 4, received $#"
     echo "Usage: integration-test [TESTING_SERVICE_URL] [TESTING_SERVICE_USER] [TESTING_SERVICE_PASS] [APP_NAMES] [[TESTS_TO_RUN]]"

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -40,6 +40,9 @@ USER=$CIRCLE_PROJECT_USERNAME
 : ${CIRCLE_BUILD_NUM?"Missing required env var"}
 BUILD_NUM=$CIRCLE_BUILD_NUM
 
+: ${CIRCLE_TEST_REPORTS?"Missing required env var"}
+: ${CIRCLE_ARTIFACTS?"Missing required env var"}
+
 # Convert APP_NAMES (comma-separated list of apps e.g appA,appB) into a JSON array
 APPS=$(echo "${APP_NAMES}" |
 	   sed 's/,/\n/g' | # a,b,c => a\nb\nc
@@ -73,6 +76,14 @@ fi
 
 echo "Job ID: $JOB_ID"
 
+install_awscli
+# aws login.
+AWS_S3_PROFILE=oidc-s3-profile
+if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
+  echo "Logging into AWS using role credentials...."
+  assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_S3_PROFILE 
+fi
+
 echo "Waiting 1 minute before polling"
 sleep 1m
 
@@ -97,6 +108,21 @@ do
     STATUS=$(cat integration-tests.out | jq '.status')
     echo "Tests status: $STATUS"
     if [[ $STATUS == '"succeeded"' ]]; then
+      TEST_WORKFLOW_ID=$(cat integration-tests.out | jq '.testWorkflowID')
+      echo "Downloading test artifacts"
+      mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      S3_BUCKET_URL="s3://frontend-to-end-tester-files/${TEST_WORKFLOW_ID}/artifacts.zip"
+      echo "  Source: $S3_BUCKET_URL"
+      echo "  Desination: $CIRCLE_ARTIFACTS"
+      if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
+          echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
+          aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+      else
+          echo "Downloading files from S3 using static credentials" 
+          aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+      fi
+      unzip $CIRCLE_ARTIFACTS/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS
+
       rm -f integration-tests.out
       exit 0
     elif [[ $STATUS == '"testsFailed"' ]]; then
@@ -107,6 +133,22 @@ do
       echo "------------------------------------------------"
       ENV=$(jq .environment < integration-tests.out)
       echo "Tests ran in staging environment: ${ENV:-<not sure>}"
+
+      TEST_WORKFLOW_ID=$(cat integration-tests.out | jq '.testWorkflowID')
+      echo "Downloading test artifacts"
+      mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      S3_BUCKET_URL="s3://frontend-to-end-tester-files/${TEST_WORKFLOW_ID}/artifacts.zip"
+      echo "  Source: $S3_BUCKET_URL"
+      echo "  Desination: $CIRCLE_ARTIFACTS"
+      if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
+          echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
+          aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+      else
+          echo "Downloading files from S3 using static credentials" 
+          aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+      fi
+      unzip $CIRCLE_ARTIFACTS/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS
+
       rm -f integration-tests.out
       exit 1
     elif [[ $STATUS == '"systemError"' ]]; then

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -129,9 +129,7 @@ do
   if [[ $SC -eq 200 ]]; then
     echo "------------------------------------------------"
     STATUS=$(cat integration-tests.out | jq '.status')
-    OUT=$(cat integration-tests.out | jq)
     echo "Tests status: $STATUS"
-    echo "Out: $OUT"
     if [[ $STATUS == '"succeeded"' ]]; then
       download_test_artifacts
       rm -f integration-tests.out

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -98,10 +98,7 @@ download_test_artifacts(){
     echo "  Desination: $DEST"
     if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
         echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
-        aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $DEST
-    else
-        echo "Downloading files from S3 using static credentials" 
-        aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+        aws s3 cp --profile $AWS_S3_PROFILE $S3_BUCKET_URL $DEST
     fi
     unzip $DEST test-results.xml -d $CIRCLE_TEST_REPORTS/${workflowID}
   done

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -87,6 +87,23 @@ if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
   assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_S3_PROFILE 
 fi
 
+download_test_artifacts(){
+  echo "Downloading test artifacts"
+  mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+  TEST_WORKFLOW_ID=$(cat integration-tests.out | jq '.testWorkflowID')
+  S3_BUCKET_URL="s3://frontend-to-end-tester-files/${TEST_WORKFLOW_ID}/artifacts.zip"
+  echo "  Source: $S3_BUCKET_URL"
+  echo "  Desination: $CIRCLE_ARTIFACTS"
+  if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
+      echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
+      aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+  else
+      echo "Downloading files from S3 using static credentials" 
+      aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
+  fi
+  unzip $CIRCLE_ARTIFACTS/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS
+}
+
 echo "Waiting 1 minute before polling"
 sleep 1m
 
@@ -111,21 +128,7 @@ do
     STATUS=$(cat integration-tests.out | jq '.status')
     echo "Tests status: $STATUS"
     if [[ $STATUS == '"succeeded"' ]]; then
-      TEST_WORKFLOW_ID=$(cat integration-tests.out | jq '.testWorkflowID')
-      echo "Downloading test artifacts"
-      mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-      S3_BUCKET_URL="s3://frontend-to-end-tester-files/${TEST_WORKFLOW_ID}/artifacts.zip"
-      echo "  Source: $S3_BUCKET_URL"
-      echo "  Desination: $CIRCLE_ARTIFACTS"
-      if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
-          echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
-          aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $CIRCLE_ARTIFACTS
-      else
-          echo "Downloading files from S3 using static credentials" 
-          aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
-      fi
-      unzip $CIRCLE_ARTIFACTS/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS
-
+      download_test_artifacts
       rm -f integration-tests.out
       exit 0
     elif [[ $STATUS == '"testsFailed"' ]]; then
@@ -136,22 +139,7 @@ do
       echo "------------------------------------------------"
       ENV=$(jq .environment < integration-tests.out)
       echo "Tests ran in staging environment: ${ENV:-<not sure>}"
-
-      TEST_WORKFLOW_ID=$(cat integration-tests.out | jq '.testWorkflowID')
-      echo "Downloading test artifacts"
-      mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-      S3_BUCKET_URL="s3://frontend-to-end-tester-files/${TEST_WORKFLOW_ID}/artifacts.zip"
-      echo "  Source: $S3_BUCKET_URL"
-      echo "  Desination: $CIRCLE_ARTIFACTS"
-      if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
-          echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
-          aws s3 cp --profile $AWS_S3_PROFILE  $S3_BUCKET_URL $CIRCLE_ARTIFACTS
-      else
-          echo "Downloading files from S3 using static credentials" 
-          aws s3 cp $S3_BUCKET_URL $CIRCLE_ARTIFACTS
-      fi
-      unzip $CIRCLE_ARTIFACTS/artifacts.zip test-results.xml -d $CIRCLE_TEST_REPORTS
-
+      download_test_artifacts
       rm -f integration-tests.out
       exit 1
     elif [[ $STATUS == '"systemError"' ]]; then

--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -76,7 +76,7 @@ echo "Submitting to integration-testing-service..."
 #   rm -f integration-tests.out
 #   exit 1
 # fi
-JOB_ID="ba147bda-894a-4ad0-b2f1-9c53fc547cd7"
+JOB_ID="c7f67fa9-813f-4850-b28a-0c6c8c409ece"
 echo "Job ID: $JOB_ID"
 
 install_awscli
@@ -108,7 +108,7 @@ download_test_artifacts(){
 }
 
 echo "Waiting 1 minute before polling"
-sleep 1m
+# sleep 1m
 
 echo "Polling every 30 seconds for test completion"
 
@@ -118,7 +118,7 @@ echo "Polling every 30 seconds for test completion"
 MAX_POLLS=90
 for ((i=1;i<=MAX_POLLS;i++))
 do
-  sleep 30s
+  # sleep 30s
   SC=$(curl -u $TESTING_SERVICE_USER:$TESTING_SERVICE_PASS \
     -w "%{http_code}" \
     --output integration-tests.out \


### PR DESCRIPTION
## Overview
Download e2e test artifacts from s3 after integration-test completes.
Test artifacts are in the `s3://frontend-to-end-tester-files-dev` bucket, prefixed with the fe2e workflow id. This script will download  the files into `$CIRCLE_ARTIFACTS` dir and extracts the test result file into `$CIRCLE_TEST_REPORTS`. CI workflows will be responsible for storing the artifacts / results to CircleCI using `store_artifacts` and `store_test_results`

## Testing
### Uploads artifacts for successful tests
https://app.circleci.com/pipelines/github/Clever/frontend-to-end-tester?branch=did-1644
- WIP, should work after https://github.com/Clever/circle-ci-integrations/pull/167 is merged
- **Update**: https://app.circleci.com/pipelines/github/Clever/frontend-to-end-tester/1051/workflows/5b84032d-540c-4ab1-8625-a40e133617e9/jobs/1109/tests

### Uploads artifacts for test failures
https://github.com/Clever/frontend-to-end-tester/compare/did-1644-test-failure
https://app.circleci.com/pipelines/github/Clever/frontend-to-end-tester?branch=did-1644-test-failure
[Test tab](https://app.circleci.com/pipelines/github/Clever/frontend-to-end-tester/1052/workflows/66130451-a815-44b2-ace7-482ae330b362/jobs/1098/tests)
[Artifacts tab](https://app.circleci.com/pipelines/github/Clever/frontend-to-end-tester/1052/workflows/66130451-a815-44b2-ace7-482ae330b362/jobs/1098/artifacts)