### PR TITLE
Skip docker builds if image already exists

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -107,12 +107,16 @@ if [[ -n $ECR_BUILD_ID ]]; then
   ecr_login us-west-1 $ECR_BUILD_ID $ECR_BUILD_SECRET
 fi
 
-echo "Building docker image..." 
-if [ $readopt == "private-repos" ]; then
-  echo "With Private Repos..."
-  DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
+if [ -n "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
+  echo "Building docker image..." 
+  if [ $readopt == "private-repos" ]; then
+    echo "With Private Repos..."
+    DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
+  else
+    docker build -t $ORG/$REPO:$SHORT_SHA .
+  fi
 else
-  docker build -t $ORG/$REPO:$SHORT_SHA .
+  echo "Image already exists... skipping build"
 fi
 
 # ECR login.

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -107,7 +107,7 @@ if [[ -n $ECR_BUILD_ID ]]; then
   ecr_login us-west-1 $ECR_BUILD_ID $ECR_BUILD_SECRET
 fi
 
-if [ -n "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
+if [ -z "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
   echo "Building docker image..." 
   if [ $readopt == "private-repos" ]; then
     echo "With Private Repos..."


### PR DESCRIPTION
JIRA: https://clever.atlassian.net/browse/INFRANG-5786

Skipping the docker build step in docker-publish allows using a different method to build docker images, such as a method to utilize caching, e.g. [this circleci yaml](https://github.com/Clever/otel-aggregator/blob/a81544b934b3fbe2a176cae4f58d050de705cab8/.circleci/config.yml#L26-L30). 

# Testing
* [CI job building docker build beforehand](https://app.circleci.com/pipelines/github/Clever/otel-aggregator/13/workflows/bfeb3576-ef87-490f-a600-8d90871ffaac/jobs/29)
* Testing opposite case, [CI job building docker images as normal](https://app.circleci.com/pipelines/github/Clever/otel-aggregator/14/workflows/28d2bdf6-4645-4536-b788-bfbd4286a64d/jobs/33)

