### PR TITLE
Do role-based ECR login before attempting to build

### DIFF
--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -107,18 +107,6 @@ if [[ -n $ECR_BUILD_ID ]]; then
   ecr_login us-west-1 $ECR_BUILD_ID $ECR_BUILD_SECRET
 fi
 
-if [ -z "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
-  echo "Building docker image..." 
-  if [ $readopt == "private-repos" ]; then
-    echo "With Private Repos..."
-    DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
-  else
-    docker build -t $ORG/$REPO:$SHORT_SHA .
-  fi
-else
-  echo "Image already exists... skipping build"
-fi
-
 # ECR login.
 if [[ -z $OIDC_ECR_UPLOAD_ROLE ]]; then
   echo "Logging into ECR using static credentials..."
@@ -133,6 +121,18 @@ else
   ecr_login_with_profile $ECR_REGION_US_WEST_2
   ecr_login_with_profile $ECR_REGION_US_EAST_1
   ecr_login_with_profile $ECR_REGION_US_EAST_2
+fi
+
+if [ -z "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
+  echo "Building docker image..." 
+  if [ $readopt == "private-repos" ]; then
+    echo "With Private Repos..."
+    DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
+  else
+    docker build -t $ORG/$REPO:$SHORT_SHA .
+  fi
+else
+  echo "Image already exists... skipping build"
 fi
 
 echo "Pushing to ECR..."

--- a/circleci/docker-publish
+++ b/circleci/docker-publish
@@ -104,7 +104,26 @@ install_awscli
 echo "If necessary, add the ECR_BUILD_ID and ECR_BUILD_SECRET env vars to circle manually."
 echo "They can be found in init-service as CI_ECR_XXX_KEY and CI_ECR_XXX_SECRET."
 if [[ -n $ECR_BUILD_ID ]]; then
-  ecr_login us-west-1 $ECR_BUILD_ID $ECR_BUILD_SECRET
+  if [[ -z $OIDC_ECR_UPLOAD_ROLE ]]; then
+    echo "Logging into ECR in us-west-1 using static credentials..."
+    ecr_login us-west-1 $ECR_BUILD_ID $ECR_BUILD_SECRET
+  else
+    echo "Logging into ECR using role credentials..."
+    assume_role_with_web_identity $OIDC_ECR_UPLOAD_ROLE $AWS_ECR_PROFILE 
+    ecr_login_with_profile $ECR_REGION_US_WEST_1
+  fi
+fi
+
+if [ -z "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
+  echo "Building docker image..." 
+  if [ $readopt == "private-repos" ]; then
+    echo "With Private Repos..."
+    DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
+  else
+    docker build -t $ORG/$REPO:$SHORT_SHA .
+  fi
+else
+  echo "Image already exists... skipping build"
 fi
 
 # ECR login.
@@ -121,18 +140,6 @@ else
   ecr_login_with_profile $ECR_REGION_US_WEST_2
   ecr_login_with_profile $ECR_REGION_US_EAST_1
   ecr_login_with_profile $ECR_REGION_US_EAST_2
-fi
-
-if [ -z "$(docker images -q $ORG/$REPO:$SHORT_SHA)" ]; then 
-  echo "Building docker image..." 
-  if [ $readopt == "private-repos" ]; then
-    echo "With Private Repos..."
-    DOCKER_BUILDKIT=1 docker build --ssh default -t $ORG/$REPO:$SHORT_SHA . 
-  else
-    docker build -t $ORG/$REPO:$SHORT_SHA .
-  fi
-else
-  echo "Image already exists... skipping build"
 fi
 
 echo "Pushing to ECR..."


### PR DESCRIPTION
# Jira
[SECNG-2572](https://clever.atlassian.net/browse/SECNG-2572)

# Overview
The sphinx-api build step in CI is borked. Specifically, because ECR_BUILD_ID was defined as env variable for sphinx-api's CI repository, the `docker- build` step was trying to use the `ecr_login` that still used the static credentials. 

This adds the logic to determine whether to use role-based or static credentials, in the case ECR_BUILD_ID is defined.

# Testing
Run this version for https://github.com/Clever/sphinx-api/pull/104 and see the CI succeed ( https://app.circleci.com/pipelines/github/Clever/sphinx-api/137/workflows/99557547-ce9f-4a51-88cd-30f8068815a9/jobs/254 )


[SECNG-2572]: https://clever.atlassian.net/browse/SECNG-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ