### PR TITLE
[INFRANG-6699] Build with goci

### DIFF
--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -79,11 +79,15 @@ func run(mode string) error {
 			return err
 		}
 
-		for dockerfile, tags := range dockerTargets {
-			if err = dkr.Build(ctx, ".", dockerfile, tags); err != nil {
+		for dockerfile, t := range dockerTargets {
+			if err = repo.ExecBuild(t.Command); err != nil {
 				return err
 			}
-			if err = dkr.Push(ctx, tags); err != nil {
+
+			if err = dkr.Build(ctx, ".", dockerfile, t.Tags); err != nil {
+				return err
+			}
+			if err = dkr.Push(ctx, t.Tags); err != nil {
 				return err
 			}
 		}

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -92,8 +92,12 @@ func run(mode string) error {
 	if len(lambdaTargets) > 0 {
 		lmda := lambda.New(ctx)
 
-		for artifact, binary := range lambdaTargets {
-			if err := lmda.Publish(ctx, binary, artifact); err != nil {
+		for artifact, t := range lambdaTargets {
+			if err = repo.ExecBuild(t.Command); err != nil {
+				return err
+			}
+
+			if err = lmda.Publish(ctx, t.Zip, artifact); err != nil {
 				return err
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Clever/ci-scripts
 go 1.22
 
 require (
-	github.com/Clever/catapult/gen-go/models v1.199.0
+	github.com/Clever/catapult/gen-go/models v1.199.1-0.20250110052250-7b3e32105523
 	github.com/Clever/circle-ci-integrations/gen-go/client v0.0.0-20230317164210-4d554db10fa0
 	github.com/Clever/circle-ci-integrations/gen-go/models v0.0.0-20230317164210-4d554db10fa0
 	github.com/Clever/wag/logging/wagclientlogger v0.0.0-20230227191614-7aa97ba44ab1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Clever/catapult/gen-go/models v1.199.0 h1:U/XVLo8fMQBG+XSauW/SfpLfjuCvfvkfkszMKEoOstw=
 github.com/Clever/catapult/gen-go/models v1.199.0/go.mod h1:KycooNSZj8fMqRjzFimkzDkcllvrVQ4v30EdZRfS0tU=
+github.com/Clever/catapult/gen-go/models v1.199.1-0.20250110052250-7b3e32105523 h1:s93QOYV1DyiKORnNHoRucagKdNEpQfYRIEdLy342kbs=
+github.com/Clever/catapult/gen-go/models v1.199.1-0.20250110052250-7b3e32105523/go.mod h1:KycooNSZj8fMqRjzFimkzDkcllvrVQ4v30EdZRfS0tU=
 github.com/Clever/circle-ci-integrations/gen-go/client v0.0.0-20230317164210-4d554db10fa0 h1:QlgvxlCkH2wvVBPEBCTzVFnFZTlXfkqu0Q+GFaXoBWo=
 github.com/Clever/circle-ci-integrations/gen-go/client v0.0.0-20230317164210-4d554db10fa0/go.mod h1:b6cswTCs4/PCtMyAUrOS7iEtUvhAzmFrbvYfdxZ7vHQ=
 github.com/Clever/circle-ci-integrations/gen-go/models v0.0.0-20230317164210-4d554db10fa0 h1:J+Nimwh3a/uPETcJprzZ9PFzDVidm1rfSc4XbZQdbNc=

--- a/internal/catapult/catapult.go
+++ b/internal/catapult/catapult.go
@@ -45,6 +45,7 @@ func New() *Catapult {
 // Publish a list of build artifacts to catapult.
 func (c *Catapult) Publish(ctx context.Context, artifacts []*Artifact) error {
 	for _, art := range artifacts {
+		fmt.Println("Publishing", art.ID)
 		err := c.client.PostCatapultV2(ctx, &models.CatapultPublishRequest{
 			Username: environment.CircleUser,
 			Reponame: environment.Repo,

--- a/internal/docker/targets.go
+++ b/internal/docker/targets.go
@@ -9,15 +9,22 @@ import (
 	"github.com/Clever/ci-scripts/internal/repo"
 )
 
+type DockerTarget struct {
+	// Tags are the list of tags to push for the built docker image.
+	Tags []string
+	// Command is the command to run to build the lambda artifact.
+	Command string
+}
+
 // BuildTargets returns a map of dockerfile path keys with their
 // associated tags for pushing to a remote repository. If multiple apps
 // share a repository then only the first matching Dockerfile and its
 // set of tags will be in the final list. This is an optimization so we
 // do not build multiple copies of the same Dockerfile which only differ
 // at runtime.
-func BuildTargets(apps map[string]*models.LaunchConfig) (map[string][]string, []*catapult.Artifact) {
+func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]DockerTarget, []*catapult.Artifact) {
 	var (
-		targets   = map[string][]string{}
+		targets   = map[string]DockerTarget{}
 		done      = map[string]struct{}{}
 		artifacts []*catapult.Artifact
 	)
@@ -55,7 +62,10 @@ func BuildTargets(apps map[string]*models.LaunchConfig) (map[string][]string, []
 			tags = append(tags, tag)
 		}
 
-		targets[repo.Dockerfile(launch)] = tags
+		targets[repo.Dockerfile(launch)] = DockerTarget{
+			Tags:    tags,
+			Command: repo.BuildCommand(launch),
+		}
 	}
 	return targets, artifacts
 }

--- a/internal/lambda/targets.go
+++ b/internal/lambda/targets.go
@@ -10,15 +10,25 @@ import (
 	"github.com/Clever/ci-scripts/internal/repo"
 )
 
+// LambdaTarget represents the information needed to build and publish a
+// lambda to S3.
+type LambdaTarget struct {
+	// Zip is the the path to where the lambda artifact will be located
+	// on the local FS
+	Zip string
+	// Command is the command to run to build the lambda artifact
+	Command string
+}
+
 // BuildTargets returns a set of lambda targets to build and publish to
 // S3 as well as a list of artifacts to be published to catapult. The
 // targets map has the artifact name as the key and the already built
-// local archive location as the value. Any apps with a shared artifact
+// local zip location as the value. Any apps with a shared artifact
 // will have only one entry in the map, but will still have individual
 // entries in the catapult build artifacts
-func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]string, []*catapult.Artifact) {
+func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]LambdaTarget, []*catapult.Artifact) {
 	var (
-		targets   = map[string]string{}
+		targets   = map[string]LambdaTarget{}
 		done      = map[string]struct{}{}
 		artifacts []*catapult.Artifact
 	)
@@ -42,10 +52,10 @@ func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]string, []*c
 			continue
 		}
 		done[artifact] = struct{}{}
-		// Right now we aren't yet building source code into zips in
-		// this application so we will just pull the assumed built file
-		// name from the existing CI script until we do handle this.
-		targets[artifact] = fmt.Sprintf("./bin/%s.zip", name)
+		targets[artifact] = LambdaTarget{
+			Zip:     fmt.Sprintf("./bin/%s.zip", name),
+			Command: repo.BuildCommand(launch),
+		}
 	}
 	return targets, artifacts
 }

--- a/internal/lambda/targets.go
+++ b/internal/lambda/targets.go
@@ -53,7 +53,7 @@ func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]LambdaTarget
 		}
 		done[artifact] = struct{}{}
 		targets[artifact] = LambdaTarget{
-			Zip:     fmt.Sprintf("./bin/%s.zip", name),
+			Zip:     fmt.Sprintf("./bin/%s.zip", artifact),
 			Command: repo.BuildCommand(launch),
 		}
 	}

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -142,6 +142,7 @@ func ExecBuild(c string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run build command: %v", err)
 	}
+	fmt.Println("Build command completed successfully")
 
 	return nil
 }

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 
@@ -117,4 +118,30 @@ func ArtifactName(appName string, lc *models.LaunchConfig) string {
 		artifactName = lc.Build.Artifact.Name
 	}
 	return artifactName
+}
+
+func BuildCommand(lc *models.LaunchConfig) string {
+	if lc.Build == nil || lc.Build.Artifact == nil {
+		return ""
+	}
+	return lc.Build.Artifact.Command
+}
+
+func ExecBuild(c string) error {
+	if c == "" {
+		return nil
+	}
+
+	args := strings.Split(c, "")
+	cmd := exec.Command(args[0], args[1:]...)
+	fmt.Println("Running build command:", cmd.String())
+
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run build command: %v", err)
+	}
+
+	return nil
 }

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -132,7 +132,7 @@ func ExecBuild(c string) error {
 		return nil
 	}
 
-	args := strings.Split(c, "")
+	args := strings.Split(c, " ")
 	cmd := exec.Command(args[0], args[1:]...)
 	fmt.Println("Running build command:", cmd.String())
 


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6699

# About
This PR adds functionality to goci to build artifacts, thus opening the door to further optimization and easier adoption.

# Testing
https://app.circleci.com/pipelines/github/Clever/catapult/4796/workflows/0c94c08b-7b56-46a0-9ea7-9731b862c853/jobs/7674

In this CI build, goci detects changes, builds, publishes, and if it were on main branch, it would also deploy.