### PR TITLE
[INFRANG-6712] Call catalogue sync service from goci

### DIFF
--- a/internal/catapult/catapult.go
+++ b/internal/catapult/catapult.go
@@ -73,6 +73,9 @@ func (c *Catapult) Publish(ctx context.Context, artifacts []*Artifact) error {
 	return grp.Wait()
 }
 
+// Deploy a list of apps via catapult. Note that it is only possible to
+// deploy to production, even if you pass an env param to
+// circle-ci-integrations, which seems to ignore the param.
 func (c *Catapult) Deploy(ctx context.Context, apps []string) error {
 	for _, app := range apps {
 		fmt.Println("Deploying", app)

--- a/internal/catapult/catapult.go
+++ b/internal/catapult/catapult.go
@@ -65,7 +65,7 @@ func (c *Catapult) Publish(ctx context.Context, artifacts []*Artifact) error {
 				App: art.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to sync catalog app %s with catapult: %v", art.ID, err)
+				return fmt.Errorf("failed to sync catalog app %s with catalogue config: %v", art.ID, err)
 			}
 			return nil
 		})

--- a/internal/docker/targets.go
+++ b/internal/docker/targets.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Clever/ci-scripts/internal/repo"
 )
 
+// DockerTarget contains information about how to build and push a
+// docker build target.
 type DockerTarget struct {
 	// Tags are the list of tags to push for the built docker image.
 	Tags []string
@@ -16,12 +18,12 @@ type DockerTarget struct {
 	Command string
 }
 
-// BuildTargets returns a map of dockerfile path keys with their
-// associated tags for pushing to a remote repository. If multiple apps
-// share a repository then only the first matching Dockerfile and its
-// set of tags will be in the final list. This is an optimization so we
-// do not build multiple copies of the same Dockerfile which only differ
-// at runtime.
+// BuildTargets returns a map of dockerfile path keys with their build
+// command and associated tags for pushing to a remote repository. If
+// multiple apps share a repository then only the first matching
+// Dockerfile and its set of tags will be in the final list. This is an
+// optimization so we do not build multiple copies of the same
+// Dockerfile which only differ at runtime.
 func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]DockerTarget, []*catapult.Artifact) {
 	var (
 		targets   = map[string]DockerTarget{}

--- a/internal/lambda/targets.go
+++ b/internal/lambda/targets.go
@@ -22,10 +22,10 @@ type LambdaTarget struct {
 
 // BuildTargets returns a set of lambda targets to build and publish to
 // S3 as well as a list of artifacts to be published to catapult. The
-// targets map has the artifact name as the key and the already built
-// local zip location as the value. Any apps with a shared artifact
-// will have only one entry in the map, but will still have individual
-// entries in the catapult build artifacts
+// targets map has the artifact name as the key and a build command and
+// destination zip file in the value struct. Any apps with a shared
+// artifact will have only one entry in the map, but will still have
+// individual entries in the catapult build artifacts
 func BuildTargets(apps map[string]*models.LaunchConfig) (map[string]LambdaTarget, []*catapult.Artifact) {
 	var (
 		targets   = map[string]LambdaTarget{}

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -120,6 +120,8 @@ func ArtifactName(appName string, lc *models.LaunchConfig) string {
 	return artifactName
 }
 
+// BuildCommand returns the build command for the application artifact,
+// if any is specified. Otherwise it returns an empty string.
 func BuildCommand(lc *models.LaunchConfig) string {
 	if lc.Build == nil || lc.Build.Artifact == nil {
 		return ""
@@ -127,6 +129,8 @@ func BuildCommand(lc *models.LaunchConfig) string {
 	return lc.Build.Artifact.Command
 }
 
+// ExecBuild runs the build command for the application artifact, if any
+// exists. If the command is empty, it returns nil after performing nop.
 func ExecBuild(c string) error {
 	if c == "" {
 		return nil


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6712

# About
This PR moves the catalog sync service calls to goci. This change makes it so that when you add goci, you can simply delete all the scripts it replaces instead of needing a new catalog sync service-only script.

# Testing
Testing in a catapult branch in this CI run: https://app.circleci.com/pipelines/github/Clever/catapult/4808/workflows/bc4345ad-3843-4d3c-8b51-1d6ec0096f89/jobs/7683