### PR TITLE
don't allow building with slashes in branch names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ release:
 		-o="artifacts/goci-$(VERSION)-darwin-amd64" ./cmd/goci
 	@GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X main.version=$(VERSION)" \
 		-o="artifacts/goci-$(VERSION)-darwin-arm64" ./cmd/goci
+
+install_deps:
+	go mod vendor

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -32,6 +32,10 @@ func main() {
 }
 
 func run(mode string) error {
+	if strings.Contains(environment.Branch, "/") {
+		return fmt.Errorf("branch name %s contains a `/` character, which is not supported by catapult", environment.Branch)
+	}
+
 	apps, err := repo.DiscoverApplications("./launch")
 	if err != nil {
 		return err


### PR DESCRIPTION
Jira: https://clever.atlassian.net/browse/INFRANG-5601

Overview: 
Catapult errors with `"Error: json: cannot unmarshal number into Go value of type models.NotFound"` if there are slashes in branch name. Its quite hard to support them in catapult so instead lets just not allow building if slashes are found.

# Testing
```
> cd testApp && LOCAL=true CIRCLE_SHA1="aaaaaaaaaaaaa" CIRCLE_BRANCH="bad/branch" ./goci detect
branch name bad/branch contains a `/` character, which is not supported by catapult
```
#