### PR TITLE
[INFRANG-6736] Don't error out when catalog sync fails, just print a warning

### DIFF
--- a/internal/catapult/catapult.go
+++ b/internal/catapult/catapult.go
@@ -65,7 +65,7 @@ func (c *Catapult) Publish(ctx context.Context, artifacts []*Artifact) error {
 				App: art.ID,
 			})
 			if err != nil {
-				return fmt.Errorf("failed to sync catalog app %s with catalogue config: %v", art.ID, err)
+				fmt.Println("failed to sync catalog app", art.ID, "with catalogue config:", err)
 			}
 			return nil
 		})


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6736

# About
Catalog sync is in flux right now due to the changes for the backstage; at the same time, our repo structure is in flux because of dev ex improvements. This is causing some fighting between the two: [example](https://app.circleci.com/pipelines/github/Clever/circleci-orbs/70/workflows/a67552ff-d4f6-472b-80e2-ac285d19c488/jobs/396). Catalog sync is not critical to CI, and the common case should pass just fine. We can print a warning instead of failing for now until the two different dev ex projects arrive on a way to get along.

# Testing
Simple change to prevent an error from failing CI.