### PR TITLE
Updating goci to check for go version.

### DIFF
--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/Clever/ci-scripts/internal/repo"
 )
 
-const usage = "usage: goci <detect|artifact-build-publish-deploy>"
+const usage = "usage: goci <validate|detect|artifact-build-publish-deploy>"
 
 // This app assumes the code has been checked out and that the
 // repository is the working directory.
@@ -38,10 +38,6 @@ func main() {
 }
 
 func run(mode string) error {
-	if err := validateRun(); err != nil {
-		return err
-	}
-
 	apps, err := repo.DiscoverApplications("./launch")
 	if err != nil {
 		return err
@@ -53,6 +49,13 @@ func run(mode string) error {
 	}
 
 	switch mode {
+	case "validate":
+		err := validateRun()
+		if err != nil {
+			fmt.Fprintln(os.Stdout, err)
+			return err
+		}
+		return nil
 	case "detect":
 		fmt.Println(strings.Join(appIDs, " "))
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/Clever/ci-scripts
 
-go 1.22
+go 1.22.0
+
+toolchain go1.22.11
 
 require (
 	github.com/Clever/catapult/gen-go/models v1.199.1-0.20250110052250-7b3e32105523
@@ -16,6 +18,7 @@ require (
 	github.com/docker/docker v23.0.2+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/moby/buildkit v0.11.5
+	golang.org/x/mod v0.23.0
 	golang.org/x/sync v0.10.0
 )
 
@@ -69,7 +72,6 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
-	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Clever/catapult/gen-go/models v1.199.0 h1:U/XVLo8fMQBG+XSauW/SfpLfjuCvfvkfkszMKEoOstw=
-github.com/Clever/catapult/gen-go/models v1.199.0/go.mod h1:KycooNSZj8fMqRjzFimkzDkcllvrVQ4v30EdZRfS0tU=
 github.com/Clever/catapult/gen-go/models v1.199.1-0.20250110052250-7b3e32105523 h1:s93QOYV1DyiKORnNHoRucagKdNEpQfYRIEdLy342kbs=
 github.com/Clever/catapult/gen-go/models v1.199.1-0.20250110052250-7b3e32105523/go.mod h1:KycooNSZj8fMqRjzFimkzDkcllvrVQ4v30EdZRfS0tU=
 github.com/Clever/circle-ci-integrations/gen-go/client v0.0.0-20230317164210-4d554db10fa0 h1:QlgvxlCkH2wvVBPEBCTzVFnFZTlXfkqu0Q+GFaXoBWo=
@@ -308,8 +306,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6796

# About

We're planning to roll out some changes to the CI pipelines, to make sure that a repo's Go Version is up to date. We plan to start blocking / failing builds based on this criteria:

1. **If `<current version>` < `<latest version> - 1`**:
   - The CI build fails.

2. **If `<current version>` == `<latest version> - 1`**:
   - The CI build adds a PR comment to notify engineers that a new Go version has been released.
   - The build will fail in 6 months unless the version is updated.

# Checklist

- [ ] Increment the version number in [VERSION](../VERSION)
- [ ] Add release notes

# Testing
- [x] Tested Locally, with the /testApp 

If you are planning to test locally with the /testApp directory, you'll need to modify the go.mod file path (../go.mod) in the validateRun function