### PR TITLE
Fixing goci parsing of go version

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,8 @@
-v1.0.3
-goci now supports validation of go version
+v1.0.4
+updated parsing of go version from go.mod
 
 Previously:
+- goci now supports validation of go version
 - variable MASTER_COMPARE is now required for local dev
 - Instead of emitting an error on failed catalog syncs, simply warn
 - Begin publishing goci binaries

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -168,11 +168,17 @@ func validateRun() error {
 
 	f, err := modfile.Parse("./go.mod", fileBytes , nil)
 	if err != nil {
-    	panic(err)
+		return fmt.Errorf("failed to parse go.mod file: %v", err)
 	}
 
-	// trim the patch value from the authoring repositories go version
-	trimmedVersion := f.Go.Version[:len(f.Go.Version)-2]
+	// trim the patch value from the authoring repositories go version - if 2 dots are present
+	var trimmedVersion string
+	if strings.Count(f.Go.Version, ".") == 2 {
+		trimmedVersion = f.Go.Version[:len(f.Go.Version)-2]
+	} else {
+		trimmedVersion = f.Go.Version
+	}
+
 	version, e := strconv.ParseFloat(trimmedVersion, 64)
 
 	if e != nil {


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6802

# About

1. Updated parsing logic, we will trim the patch version only if 2 periods are present.
2. Removed a panic statement, seems like it makes more sense since thats what we do for all the other errors that occur.

# Checklist

- [x] Increment the version number in [VERSION](../VERSION)
- [x] Add release notes

# Testing

Tested locally, and also within [CircleCI](https://app.circleci.com/pipelines/github/Clever/district-view-service/763/workflows/99315dad-44e4-4fa1-a476-790444034e4c/jobs/2322)