### PR TITLE
[INFRANG-6854] Bugfix: the oidc token is never loaded lazily

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,8 @@
-v1.0.6
-Updating goci warning message, including recent version release date
+v1.0.7
+bugfix: dont lazy load the oidc token
 
 Previously:
+- Updating goci warning message, including recent version release date
 - Supporting lazy loading of environment variables
 - updated parsing of go version from go.mod
 - goci now supports validation of go version

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -55,9 +55,6 @@ var (
 	// OidcEcrUploadRole is the ARN of the role used to assume the ecr
 	// upload role.
 	oidcEcrUploadRole = ""
-	// circleOidcTokenV2 is the oidc token used to assume roles in CI.
-	// It is provided by circle-ci.
-	circleOidcTokenV2 = ""
 
 	// Regions is the set of regions this app should perform
 	// operations in.
@@ -173,19 +170,12 @@ func OidcEcrUploadRole() string {
 	return oidcEcrUploadRole
 }
 
-func CircleOidcTokenV2() string {
-	if circleOidcTokenV2 == "" {
-		circleOidcTokenV2 = envMustString("CIRCLE_OIDC_TOKEN_V2", false)
-	}
-	return circleOidcTokenV2
-}
-
 // AWS doesn't provide a way to get the token from a string so we will
 // use this to satisfy the interface.
 type tokenRetriever struct{}
 
 func (tokenRetriever) GetIdentityToken() ([]byte, error) {
-	return []byte(circleOidcTokenV2), nil
+	return []byte(envMustString("CIRCLE_OIDC_TOKEN_V2", false)), nil
 }
 
 // AWSCfg initializes an AWS config or exits with code 0 on failure. If


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6854

# About
During a recent change, this variable was changed so that it can be accessed by lazy loading. However, the only place it was used was internal to the package which still referenced the empty private variable.

# Checklist

- [x] Increment the version number in [VERSION](../VERSION)
- [x] Add release notes

# Testing
Blocking only catapult CI, so gonna yolo and let that CI be the test because this is a pretty simple bug. 
