### PR TITLE
INFRANG-6802 goci update

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,8 @@
-v1.0.7
-bugfix: dont lazy load the oidc token
+v1.0.8
+updated goci to catch errors for no go.mod file
 
 Previously:
+- bugfix: dont lazy load the oidc token
 - Updating goci warning message, including recent version release date
 - Supporting lazy loading of environment variables
 - updated parsing of go version from go.mod

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -162,9 +163,11 @@ func validateRun() error {
 
 	goModPath := "./go.mod"
 	fileBytes, err := os.ReadFile(goModPath)
-	if err != nil {
-		// If the go.mod file is not found, we will skip the go version check
+	// If the go.mod file is not found, we will skip the go version check
+	if errors.Is(err, os.ErrNotExist) {
 		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to read go.mod file: %v", err)
 	}
 
 	f, err := modfile.Parse("./go.mod", fileBytes, nil)

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -34,14 +34,6 @@ func (e *ValidationError) Error() string {
 	return e.Message
 }
 
-type GoModFileNotFoundError struct {
-	Message string
-}
-
-func (e *GoModFileNotFoundError) Error() string {
-	return e.Message
-}
-
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("requires 1 argument.", usage)
@@ -49,10 +41,7 @@ func main() {
 	}
 	mode := os.Args[1]
 	if err := run(mode); err != nil {
-		if _, ok := err.(*GoModFileNotFoundError); ok {
-			fmt.Println("Go Mod file not found error:", err)
-			os.Exit(3)
-		} else if _, ok := err.(*ValidationError); ok {
+		if _, ok := err.(*ValidationError); ok {
 			fmt.Println("Validation error:", err)
 			os.Exit(2) // Use a different exit code for validation errors
 		} else {
@@ -174,7 +163,8 @@ func validateRun() error {
 	goModPath := "./go.mod"
 	fileBytes, err := os.ReadFile(goModPath)
 	if err != nil {
-		return &GoModFileNotFoundError{Message: fmt.Sprintf("failed to read go.mod file: %v", err)}
+		// If the go.mod file is not found, we will skip the go version check
+		return nil
 	}
 
 	f, err := modfile.Parse("./go.mod", fileBytes, nil)


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6802

# About

The plan is to now catch this specific error that non go based repo's will run into. Which is that no go.mod file can be found. We are assuming that all go repos will have the same location of their go.mod files - and so if any repo can't find the go.mod file, it isn't a go based repo.

# Checklist

- [x] Increment the version number in [VERSION](../VERSION)
- [x] Add release notes

# Testing

- [x] Locally tested. 
- [x] To emulate this process, I tested a pull request on dvs that pulled from my branch [here](https://github.com/Clever/ci-scripts/pull/163), which called goci locally as opposed to pulling the latest version. In the local version I changed the go.mod path to an incorrect path (something that couldn't be found) so that when goci ran, it emitted the exit code 3, which we catch in the publish-catapult script. Whne an exit code of 3 occurs, we continue the publish script without erroring out which was the issue last friday (see: [On-call issue](https://clever.slack.com/archives/C08G6CNMN/p1740161538238679) and [Example of CI Failing](https://app.circleci.com/pipelines/github/Clever/sd2/27301/workflows/083d358a-126e-4d0c-b715-75da1dc3d805/jobs/170653))
