### PR TITLE
[INFRANG-6802] Disable fail on error until after we complete the full validation

### DIFF
--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -54,8 +54,9 @@ if [ -f go.mod ]; then
   GOCI_EXIT_CODE=$?
 
 
+  if [[ -z $GH_RELEASE_TOKEN ]]; then echo "Missing GH_RELEASE_TOKEN" && exit 1; fi
+
   if [[ $GOCI_EXIT_CODE -eq 2 ]]; then
-    if [[ -z $GH_RELEASE_TOKEN ]]; then echo "Missing GH_RELEASE_TOKEN" && exit 1; fi
     echo "goci failed with exit code $GOCI_EXIT_CODE"
     echo "$VALIDATE_OUTPUT"
     post_github_pr_comment $USER $REPO_NAME $FULL_SHA $GH_RELEASE_TOKEN "$VALIDATE_OUTPUT"
@@ -66,7 +67,6 @@ if [ -f go.mod ]; then
     exit $GOCI_EXIT_CODE
   fi
 
-  set -e
 
   # If a warning is present for a go based repo, we print the warning and will make a PR comment with the warning message
   if [[ -n "$VALIDATE_OUTPUT"  ]]; then
@@ -76,6 +76,7 @@ if [ -f go.mod ]; then
     post_github_pr_comment $USER $REPO_NAME $FULL_SHA $GH_RELEASE_TOKEN "$VALIDATE_OUTPUT"
   fi
 
+  set -e
   echo "goci passed."
 else
   echo "No go.mod file found. Skipping goci."


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6802

# About
I need a bit more time to debug this, so I am making it so this part of the script will not cause ci failure until I can debug it.

# Testing
Only disabling errors
