### PR TITLE
Dead 13

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,9 @@
-v1.1.0
-goci can now publish utilities to the catalog
+v1.2.0
+goci now supports validation of node version
+
 
 Previously:
+- goci can now publish utilities to the catalog
 - updated goci to catch errors for no go.mod file
 - bugfix: dont lazy load the oidc token
 - Updating goci warning message, including recent version release date

--- a/circleci/catapult-publish
+++ b/circleci/catapult-publish
@@ -43,8 +43,8 @@ REPO_NAME=$CIRCLE_PROJECT_REPONAME
 SHORT_SHA=${CIRCLE_SHA1:0:7}
 FULL_SHA=${CIRCLE_SHA1}
 
-# If file go.mod exists
-if [ -f go.mod ]; then
+# If file go.mod or package.json exists
+if [ -f go.mod ] || [ -f package.json ]; then
   . $DIR/install-goci
 
   set +e

--- a/cmd/goci/README.md
+++ b/cmd/goci/README.md
@@ -10,7 +10,7 @@ goci accepts very limited arguments which merely change the mode it runs in. The
 
 1. `goci detect` detects any changed applications according to their launch configuration. This can be used to pass a name of apps to another script.
 2. `goci artifact-build-publish-deploy` builds, publishes and deploys any application artifacts.
-3. `goci validate` validates an applications go version, while also checking for compatible branch naming conventions for catapult.
+3. `goci validate` validates an applications go version and node version, while also checking for compatible branch naming conventions for catapult.
 4. `goci publish-utility` publishes catalog-info.yaml to the service catalog.
 
 

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -255,6 +255,7 @@ func parseCurrentNodeMajorVersion() (string, error) {
 }
 
 func validateNodeVersion() error {
+	minimumEnforcementVersion := 22 
 	ltsVersion, ltsReleaseDate, err := fetchLastestLTSNodeVersion()
 	if err != nil {
 		return err
@@ -279,7 +280,9 @@ func validateNodeVersion() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse LTS major version: %v", err)
 	}
-	if currentMajorVersionInt < ltsMajorVersionInt {
+	// Check if the current major version is less than the LTS major version
+	// and that we have already performed the initial migration to get to at least the minimum enforcement version
+	if currentMajorVersionInt < ltsMajorVersionInt && currentMajorVersionInt >= minimumEnforcementVersion {
 		// parse the release date of the LTS version
 		releaseDate, err := time.Parse("2006-01-02", ltsReleaseDate)
 		if err != nil {

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -255,7 +255,7 @@ func parseCurrentNodeMajorVersion() (string, error) {
 }
 
 func validateNodeVersion() error {
-	minimumEnforcementVersion := 22 
+	minimumEnforcementVersion := 24
 	ltsVersion, ltsReleaseDate, err := fetchLastestLTSNodeVersion()
 	if err != nil {
 		return err

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/mod/modfile"
 
@@ -160,12 +162,126 @@ func run(mode string) error {
 	return nil
 }
 
-// validateRun checks the env.branch and go version to ensure the build is valid.
-func validateRun() error {
-	if strings.Contains(environment.Branch(), "/") {
-		return &ValidationError{Message: fmt.Sprintf("branch name %s contains a `/` character, which is not supported by catapult", environment.Branch())}
+// gets the most recent Long Term Support (LTS) Node.js version from https://nodejs.org/dist/index.json
+func fetchLastestLTSNodeVersion() (string, string, error) {
+	resp, err := http.Get("https://nodejs.org/dist/index.json")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to fetch Node.js versions: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("failed to fetch Node.js versions: status code %d", resp.StatusCode)
 	}
 
+	// Read the response body to json array
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	// Parse the JSON response
+	var nodeReleases []map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &nodeReleases); err != nil {
+		return "", "", fmt.Errorf("failed to parse JSON response: %v", err)
+	}
+
+	// Find the latest LTS version
+	var latestLTSVersion string
+	var latestLTSReleaseDate string
+	for _, release := range nodeReleases {
+		if lts, ok := release["lts"]; ok && lts != nil {
+			ltsBool, boolOk := lts.(bool)
+			ltsString, stringOk := lts.(string)
+			if (boolOk && ltsBool) || (stringOk && ltsString != "") {
+				if version, ok := release["version"].(string); ok {
+					latestLTSVersion = version
+				} else {
+					return "", "", fmt.Errorf("failed to parse version in Node.js release")
+				}
+				if date, ok := release["date"].(string); ok {
+					latestLTSReleaseDate = date
+
+				} else {
+					return "", "", fmt.Errorf("failed to parse date in Node.js release")
+				}
+				break // We found the latest LTS version, no need to continue
+			}
+		}
+	}
+
+	if latestLTSVersion == "" {
+		return "", "", fmt.Errorf("no LTS version found in Node.js releases")
+	}
+	return latestLTSVersion, latestLTSReleaseDate, nil
+}
+
+func parseCurrentNodeMajorVersion() (string, error) {
+	dockerfilePath := "./Dockerfile"
+	fileBytes, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Dockerfile: %v", err)
+	}
+
+	// Use a regex to find the Node.js version in the Dockerfile
+	re := regexp.MustCompile(`FROM node:([0-9]+)`)
+	matches := re.FindStringSubmatch(string(fileBytes))
+	if len(matches) == 2 {
+		return matches[1], nil
+	}
+	// look for an explicit download of a Node.js version in the Dockerfile
+	// This is a fallback in case the Dockerfile does not use the standard Node.js image
+	re = regexp.MustCompile(`deb\.nodesource\.com\/setup_([0-9]+)\.`)
+	matches = re.FindStringSubmatch(string(fileBytes))
+	if len(matches) == 2 {
+		return matches[1], nil
+	}
+	return "", fmt.Errorf("failed to find Node.js version in Dockerfile")
+}
+
+func validateNodeVersion() error {
+	ltsVersion, ltsReleaseDate, err := fetchLastestLTSNodeVersion()
+	if err != nil {
+		return err
+	}
+	re := regexp.MustCompile(`v([0-9]+)\.`)
+	var ltsMajorVersion string
+	if matches := re.FindStringSubmatch(ltsVersion); len(matches) == 2 {
+		ltsMajorVersion = matches[1]
+	} else {
+		return fmt.Errorf("failed to parse LTS major version from %s", ltsVersion)
+	}
+	currentMajorVersion, err := parseCurrentNodeMajorVersion()
+	if err != nil {
+		return err
+	}
+	// compare the major version of the current Node.js version with the latest LTS version
+	currentMajorVersionInt, err := strconv.Atoi(currentMajorVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse current major version: %v", err)
+	}
+	ltsMajorVersionInt, err := strconv.Atoi(ltsMajorVersion)
+	if err != nil {
+		return fmt.Errorf("failed to parse LTS major version: %v", err)
+	}
+	if currentMajorVersionInt < ltsMajorVersionInt {
+		// parse the release date of the LTS version
+		releaseDate, err := time.Parse("2006-01-02", ltsReleaseDate)
+		if err != nil {
+			return fmt.Errorf("failed to parse LTS release date: %v", err)
+		}
+		if time.Since(releaseDate) > 6*30*24*time.Hour { // 6 months in hours
+			return &ValidationError{
+				Message: fmt.Sprintf("Your current Node.js version %s is no longer supported. Please upgrade to the latest Long Term Support version %s or later", currentMajorVersion, ltsVersion),
+			}
+		} else {
+			fmt.Printf("A new Node.js Long Term Support version is out, released on (%s). After 6 months of release, Your current Node.js version v%d will fail CI workflows if it is not upgraded to v%d.\n", ltsReleaseDate, currentMajorVersionInt, ltsMajorVersionInt)
+		}
+	}
+	return nil
+}
+
+func validateGoVersion() error {
 	latestGoVersion, releaseDate, err := fetchLatestGoVersion()
 	if err != nil {
 		return fmt.Errorf("failed to fetch latest Go version: %v", err)
@@ -215,6 +331,31 @@ func validateRun() error {
 	} else if repoVersion <= newestGoVersion-0.01 {
 		// We'll give a PR comment to the Author to warn them about the need to upgrade
 		fmt.Printf("A new Go version is out, released on (%v). After 6 months of release, Your current Go version (%v) will fail CI workflows if it is not upgraded.\n", releaseDate, f.Go.Version)
+	}
+
+	return nil
+}
+
+// validateRun checks the env.branch and go version to ensure the build is valid.
+func validateRun() error {
+	if strings.Contains(environment.Branch(), "/") {
+		return &ValidationError{Message: fmt.Sprintf("branch name %s contains a `/` character, which is not supported by catapult", environment.Branch())}
+	}
+
+	// if package.json exists, we will validate the Node.js version
+	if _, err := os.Stat("./package.json"); err == nil {
+		err = validateNodeVersion()
+		if err != nil {
+			return fmt.Errorf("failed to validate Node.js version: %v", err)
+		}
+	}
+
+	// if go.mod exists, we will validate the Go version
+	if _, err := os.Stat("./go.mod"); err == nil {
+		err = validateGoVersion()
+		if err != nil {
+			return fmt.Errorf("failed to validate Go version: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/DEAD-13

# About
Adding node version check. Will fail the circle ci flow if the app is not on the current LTS node version and that release has been in LTS for at least 6 months. will start being enforced after we have done the initial migration to node 24. We will look for the presence of a package.json file to determine if this check should be used


# Checklist

- [x] Increment the version number in [VERSION](../VERSION)
- [x] Add release notes

# Testing
Tested locally with apps that needed the node upgrade and those that didn't. Got the expected results in each case