### PR TITLE
[INFRANG-6811] run validate as last step on artifact-build-publish-deploy

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,8 @@
-v1.3.0
-upgrade all aws sdk v2 modules
+v1.4.0
+run validate as last step on artifact-build-publish-deploy
 
 Previously:
+- upgrade all aws sdk v2 modules
 - reverting node version validation for now
 - goci now supports validation of node version
 - goci can now publish utilities to the catalog
@@ -11,4 +12,3 @@ Previously:
 - Supporting lazy loading of environment variables
 - updated parsing of go version from go.mod
 - goci now supports validation of go version
-- variable MASTER_COMPARE is now required for local dev

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -89,11 +89,6 @@ func run(mode string) error {
 		return fmt.Errorf("unknown mode %s. %s", mode, usage)
 	}
 
-	// We want to validate on every run, not just when the mode is "validate".
-	if err = validateRun(); err != nil {
-		return err
-	}
-
 	if len(apps) == 0 {
 		fmt.Println("No applications have buildable changes. If this is unexpected, " +
 			"double check your artifact dependency configuration in the launch yaml.")
@@ -155,9 +150,13 @@ func run(mode string) error {
 	}
 
 	if environment.Branch() == "master" {
-		return cp.Deploy(ctx, appIDs)
+		if err := cp.Deploy(ctx, appIDs); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	// We want to validate on every run, not just when the mode is "validate".
+	return validateRun()
 }
 
 // validateRun checks the env.branch and go version to ensure the build is valid.


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6811

# About
* update the `artifact-build-publish-deploy` step to run the validation step very last, which will still allow builds and deploys (if on master) through but will still fail the CI if validation errors. useful for emergency deploys

# Checklist

- [x] Increment the version number in [VERSION](../VERSION)
- [x] Add release notes

# Testing
* none
