### PR TITLE
[INFRANG-8042] add support for docker builds with buildkit

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,7 @@
-v1.6.0
-Add new deploy-apps command
+v1.7.0
+Add support for docker builds with buildkit
 
 Previously:
+- Add new deploy-apps command
 - Temporarily disable Go version checks
 - Push Docker images to one ECR region
-- add option to pass branch name and dryRun to catalog-sync

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -66,6 +67,7 @@ func (d *Docker) Build(ctx context.Context, contextDir, dockerfile string, tags 
 		dockerfile = "Dockerfile"
 	}
 	fmt.Println("building", tags, "from", dockerfile, "...")
+
 	excludes, err := readDockerignore(contextDir)
 	if err != nil {
 		return fmt.Errorf("failed to read docker ignore: %v", err)
@@ -78,17 +80,49 @@ func (d *Docker) Build(ctx context.Context, contextDir, dockerfile string, tags 
 		return fmt.Errorf("failed to build docker context: %v", err)
 	}
 
-	res, err := d.cli.ImageBuild(ctx, tar, types.ImageBuildOptions{
+	if os.Getenv("DOCKER_BUILDKIT") == "1" {
+		return d.buildWithBuildkit(ctx, tar, dockerfile, tags)
+	}
+
+	buildOpts := types.ImageBuildOptions{
 		Tags:       tags,
 		Dockerfile: dockerfile,
 		// Removes any intermediary build images.
 		Remove: true,
-	})
+	}
+
+	res, err := d.cli.ImageBuild(ctx, tar, buildOpts)
 	if err != nil {
 		return fmt.Errorf("unable to build image: %v", err)
 	}
 	defer res.Body.Close()
 	return print(res.Body)
+}
+
+func (d *Docker) buildWithBuildkit(ctx context.Context, tar io.ReadCloser, dockerfile string, tags []string) error {
+	defer tar.Close()
+
+	cmd := "docker"
+	args := []string{"buildx", "build", "--load", "--rm", "-f", dockerfile}
+
+	for _, tag := range tags {
+		args = append(args, "-t", tag)
+	}
+
+	args = append(args, "-")
+
+	fmt.Println("building with buildx:", strings.Join(append([]string{cmd}, args...), " "))
+
+	buildCmd := exec.CommandContext(ctx, cmd, args...)
+	buildCmd.Stdin = tar
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+
+	if err := buildCmd.Run(); err != nil {
+		return fmt.Errorf("docker buildx build failed: %v", err)
+	}
+
+	return nil
 }
 
 // Push the tags to their private ecr repository. If a tag is not for a


### PR DESCRIPTION
# Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

# JIRA
https://clever.atlassian.net/browse/INFRANG-8042

# About
Routes builds to use docker buildkit if ` DOCKER_BUILDKIT=1`. Otel-aggregator is using buildkit and the functionality should be retained as it is migrated to use circleci orbs. See related PR: https://github.com/Clever/circleci-orbs/pull/22

# Checklist

- [X] Increment the version number in [VERSION](../VERSION)
- [X] Add release notes

# Testing
* Referenced this feature branch in otel-agg circleci config and verified the Docker image was build and pushed to ECR successfully https://app.circleci.com/pipelines/github/Clever/otel-aggregator/321/workflows/3b0b7319-42f9-484f-be02-6620608172ca
* Also verified the lambda artifacts were pushed to S3