### PR TITLE
[INFRA-108] Update the artifact bucket for fe2e tester

### DIFF
--- a/circleci/integration-test
+++ b/circleci/integration-test
@@ -84,7 +84,7 @@ install_awscli
 AWS_S3_PROFILE=oidc-s3-profile
 if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
   echo "Logging into AWS using role credentials...."
-  assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_S3_PROFILE 
+  assume_role_with_web_identity $OIDC_S3_UPLOAD_ROLE $AWS_S3_PROFILE
 fi
 
 download_test_artifacts(){
@@ -92,7 +92,7 @@ download_test_artifacts(){
   mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
   for workflowID in $(cat integration-tests.out | jq -r '.testWorkflowIds[]');
   do
-    S3_BUCKET="frontend-to-end-tester-files-dev"
+    S3_BUCKET="clever-dev-fe2e-tester-files-585008086734-us-west-2-an"
     S3_ARTIFACTS_KEY="${workflowID}/artifacts.zip"
     S3_BUCKET_URL="s3://${S3_BUCKET}/${S3_ARTIFACTS_KEY}"
     # TODO we probably at some point want to separate out the integration test script from the artifacts download
@@ -108,10 +108,10 @@ download_test_artifacts(){
     echo "  Source: $S3_BUCKET_URL"
     echo "  Desination: $DEST"
     if [[ -v OIDC_S3_UPLOAD_ROLE ]]; then
-        echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}" 
+        echo "Downloading files from S3 using profile ${AWS_S3_PROFILE}"
         aws s3 cp --profile $AWS_S3_PROFILE $S3_BUCKET_URL $DEST
     else
-        echo "Downloading files to S3 using static credentials" 
+        echo "Downloading files to S3 using static credentials"
         aws s3 cp $S3_BUCKET_URL $DEST
     fi
     unzip $DEST test-results.xml -d $CIRCLE_TEST_REPORTS/${workflowID}


### PR DESCRIPTION
# Clever Coding Standards Agreement

- [x] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

# JIRA
https://linear.app/clever/issue/INFRA-108/get-integration-tests-running-in-the-dev-account

# About
This PR updates the bucket name for fetching fe2e tester artifacts.

# Testing
I will test this by specifying a branch of ci scripts in a repo PR that uses intetration testing to verify functionality.