### PR TITLE
[INFRA-286] add SyncEntity call to k8s deployApps command

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,7 @@
-v1.7.0
-Support configurable deployment branches
+v1.8.0
+Add add SyncEntity call to k8s deployApps command
 
 Previously:
+- Support configurable deployment branches
 - Add new deploy-apps command
 - Temporarily disable Go version checks
-- Push Docker images to one ECR region

--- a/cmd/goci/main.go
+++ b/cmd/goci/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Clever/catapult/gen-go/models"
 	"github.com/Clever/ci-scripts/internal/backstage"
+	"github.com/Clever/ci-scripts/internal/catalogsync"
 	"github.com/Clever/ci-scripts/internal/catapult"
 	"github.com/Clever/ci-scripts/internal/docker"
 	"github.com/Clever/ci-scripts/internal/environment"
@@ -306,6 +307,18 @@ func deployApps(appIds []string) error {
 		return nil
 	}
 	ctx := context.Background()
+
+	cs := catalogsync.New()
+	repo := environment.Repo()
+	for _, appID := range appIds {
+		if err := cs.SyncEntity(ctx, &ciIntegrationsModels.SyncCatalogEntityInput{
+			Entity: appID,
+			Type:   "application",
+			Repo:   &repo,
+		}); err != nil {
+			fmt.Println("failed to sync catalog app", appID, "with catalog-sync-service:", err)
+		}
+	}
 
 	if shouldDeploy() {
 		if err := slingshot.New().DeployApps(ctx, appIds); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.24.0
 
 require (
 	github.com/Clever/catapult/gen-go/models v1.206.0
-	github.com/Clever/circle-ci-integrations/gen-go/client v0.14.0
-	github.com/Clever/circle-ci-integrations/gen-go/models v0.14.0
+	github.com/Clever/circle-ci-integrations/gen-go/client v0.15.0
+	github.com/Clever/circle-ci-integrations/gen-go/models v0.15.0
 	github.com/Clever/slingshot/gen-go/client v1.1.0
 	github.com/Clever/slingshot/gen-go/models v1.1.0
 	github.com/Clever/wag/logging/wagclientlogger v0.0.0-20250514163731-344287ef8d81

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,12 @@ github.com/Clever/catapult/gen-go/models v1.206.0 h1:O338A6BsJXawrcj1YRDzceapfv7
 github.com/Clever/catapult/gen-go/models v1.206.0/go.mod h1:a2Mjvx842kCgdnwgCbF8S361vdrDTeeDG/iowbCjkB0=
 github.com/Clever/circle-ci-integrations/gen-go/client v0.14.0 h1:O4XAIg8zcree7X7WVqjc2+z1a9Z13eXiiFXE6xa5hEs=
 github.com/Clever/circle-ci-integrations/gen-go/client v0.14.0/go.mod h1:wpdliPGHx46byqcV9J05VN7JUoGb5NDZFxVt7PQpMQ0=
+github.com/Clever/circle-ci-integrations/gen-go/client v0.15.0 h1:MAYlQatIz8T84YFyj3WqoGt0jA4ZVp8Esi2qyX/p/JM=
+github.com/Clever/circle-ci-integrations/gen-go/client v0.15.0/go.mod h1:wpdliPGHx46byqcV9J05VN7JUoGb5NDZFxVt7PQpMQ0=
 github.com/Clever/circle-ci-integrations/gen-go/models v0.14.0 h1:5Ys+a5lnL/GxEMxHHTu3BEjGcChQ/bFzlAHBP4zfoAo=
 github.com/Clever/circle-ci-integrations/gen-go/models v0.14.0/go.mod h1:t6kpy0bDHmkDfPkxpoc1DE49mBfo0DbEh9e5MZAJDTc=
+github.com/Clever/circle-ci-integrations/gen-go/models v0.15.0 h1:bV8NTjmbA71RAbTYIBX+4A2BqxlCOwKWawqofm+IKSI=
+github.com/Clever/circle-ci-integrations/gen-go/models v0.15.0/go.mod h1:t6kpy0bDHmkDfPkxpoc1DE49mBfo0DbEh9e5MZAJDTc=
 github.com/Clever/discovery-go v1.9.1 h1:4swV6hvVOeEVVVHkSaArczkrLlWfjXF+EtUfErcrFro=
 github.com/Clever/discovery-go v1.9.1/go.mod h1:5nAy5m+0xTg/sWA0aieT71axc6NMAqZamHpl9leNcKU=
 github.com/Clever/slingshot/gen-go/client v1.1.0 h1:ZKMc+2IY14eoILSLPgz3zVpCasHXgDmlZyl068pBOf4=

--- a/internal/catalogsync/catalogsync.go
+++ b/internal/catalogsync/catalogsync.go
@@ -1,0 +1,45 @@
+package catalogsync
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Clever/ci-scripts/internal/environment"
+	"github.com/Clever/ci-scripts/internal/logger"
+	"github.com/Clever/circle-ci-integrations/gen-go/client"
+	"github.com/Clever/circle-ci-integrations/gen-go/models"
+)
+
+type Client struct {
+	client client.Client
+}
+
+func New() *Client {
+	url := environment.CIIntegrationsUrl()
+	var rt http.RoundTripper = &basicAuthTransport{}
+	cli := client.New(url, logger.FmtPrinlnLogger{}, &rt)
+	cli.SetTimeout(15 * time.Second)
+	return &Client{client: cli}
+}
+
+func (c *Client) SyncEntity(ctx context.Context, entity *models.SyncCatalogEntityInput) error {
+	branch := environment.Branch()
+	dryRun := branch != "master"
+	entity.Branch = &branch
+	entity.DryRun = &dryRun
+
+	fmt.Printf("Syncing catalog entity %s with type %s on branch %s with dry run %t\n", entity.Entity, entity.Type, branch, dryRun)
+	if err := c.client.SyncCatalogEntity(ctx, entity); err != nil {
+		return fmt.Errorf("failed to sync catalog entity %s: %v", entity.Entity, err)
+	}
+	return nil
+}
+
+type basicAuthTransport struct{}
+
+func (ba *basicAuthTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.SetBasicAuth(environment.CIIntegrationsUser(), environment.CIIntegrationsPassword())
+	return http.DefaultTransport.RoundTrip(r)
+}

--- a/internal/catapult/catapult.go
+++ b/internal/catapult/catapult.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/Clever/ci-scripts/internal/environment"
+	"github.com/Clever/ci-scripts/internal/logger"
 	"github.com/Clever/circle-ci-integrations/gen-go/client"
 	"github.com/Clever/circle-ci-integrations/gen-go/models"
-	"github.com/Clever/ci-scripts/internal/logger"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -74,9 +74,11 @@ func (c *Catapult) Publish(ctx context.Context, artifacts []*Artifact) error {
 				return fmt.Errorf("failed to publish %s with catapult: %v", art.ID, err)
 			}
 
+			repo := environment.Repo()
 			err = c.SyncCatalogEntity(grpCtx, &models.SyncCatalogEntityInput{
 				Entity: art.ID,
 				Type:   "application",
+				Repo:   &repo,
 			})
 			if err != nil {
 				fmt.Println("failed to sync catalog app", art.ID, "with catalogue config:", err)

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -68,6 +68,12 @@ var (
 
 	// CircleTriggeredBy is the username of the user who triggered the CI run.
 	circleTriggeredBy = ""
+	// URL for circle-ci-integrations
+	ciIntegrationsURL = ""
+	// username for basic authentication to circle-ci-integrations
+	ciIntegrationsUser = ""
+	// password for basic authentication to circle-ci-integrations
+	ciIntegrationsPassword = ""
 )
 
 func ECRAccountID() string {
@@ -187,6 +193,27 @@ func SlingshotURL() string {
 		slingshotURL = envMustString("SLINGSHOT_URL", true)
 	}
 	return slingshotURL
+}
+
+func CIIntegrationsUrl() string {
+	if ciIntegrationsURL == "" {
+		ciIntegrationsURL = envMustString("CIRCLE_CI_INTEGRATIONS_URL", true)
+	}
+	return ciIntegrationsURL
+}
+
+func CIIntegrationsUser() string {
+	if ciIntegrationsUser == "" {
+		ciIntegrationsUser = envMustString("CIRCLE_CI_INTEGRATIONS_USER", true)
+	}
+	return ciIntegrationsUser
+}
+
+func CIIntegrationsPassword() string {
+	if ciIntegrationsPassword == "" {
+		ciIntegrationsPassword = envMustString("CIRCLE_CI_INTEGRATIONS_PASS", true)
+	}
+	return ciIntegrationsPassword
 }
 
 // AWS doesn't provide a way to get the token from a string so we will


### PR DESCRIPTION
# Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

# JIRA
https://linear.app/clever/issue/INFRA-286/update-circle-ci-integrations-to-send-repo-in-syncentity-request

# About
Catalog-sync-service sources info about an app's repo from Catapult at the moment. Since Catapult is on a deprecation path, we need an alternate source for the repo name. The repo name is readily available from the CircleCi context so it can propagated down to `catalog-sync-service`. 

This PR makes the change to pass the repo name to `circle-ci-integrations` which then calls `catalog-sync-service`. It also adds a SyncEntity call to the deployApps command so Kubernetes-deployed apps are guaranteed to have their info synced to the catalog on deploys to the default branch. The CIIntegrations environment variables were added to the `slingshot-ci` context.

Related PRs:
* https://github.com/Clever/circle-ci-integrations/pull/194
* https://github.com/Clever/catalog-sync-service/pull/155

# Checklist

- [X] Increment the version number in [VERSION](../VERSION)
- [X] Add release notes

# Testing
* Updated orb config in `do-nothing` to build goci from this branch: https://github.com/Clever/do-nothing/commit/272fb5ad2a36157002ae39c02cea9968a0e09cb7
* Verified circleci job ran successfully: https://app.circleci.com/pipelines/gh/Clever/do-nothing/338/workflows/054e5133-e535-45cc-ae6a-1726dea14ff6/jobs/1239
* Checked the `catalog-sync-service` logs and verified:
    * SyncEntity API was called with repo param
    * Config has correct source annotation
```
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  annotations:
    argocd/app-selector: clever.com/application=do-nothing
    circleci.com/project-slug: github/Clever/do-nothing
    clever/circle-ci-images: ""
    clever/dockerfile-images: alpine:3.10
    clever/git-default-branch: main
    clever/go-version: "1.24"
    clever/idp-platform: kubernetes
    clever/source: Clever/do-nothing
  description: An app that doesn't really do anything used to test 
...
```
  